### PR TITLE
fix: 3 failing tests (activeTask + timeEntry soft-delete)

### DIFF
--- a/lib/services/timeEntry.service.ts
+++ b/lib/services/timeEntry.service.ts
@@ -98,6 +98,12 @@ export function updateTimeEntry({
         "User does not own this time entry",
       );
 
+    const task = await client.task.findUnique({
+      where: { id: existing.taskId, deletedAt: null },
+      select: { id: true },
+    });
+    if (!task) return createServiceErrorResponse("NOT_FOUND", "Task not found");
+
     const updated = await client.timeEntry.update({
       where: { id: timeEntryId },
       data: {
@@ -129,6 +135,12 @@ export function deleteTimeEntry({
         "AUTHORIZATION_ERROR",
         "User does not own this time entry",
       );
+
+    const task = await client.task.findUnique({
+      where: { id: existing.taskId, deletedAt: null },
+      select: { id: true },
+    });
+    if (!task) return createServiceErrorResponse("NOT_FOUND", "Task not found");
 
     await client.timeEntry.delete({
       where: { id: timeEntryId },

--- a/tests/unit/services/activeTask.service.test.ts
+++ b/tests/unit/services/activeTask.service.test.ts
@@ -61,6 +61,7 @@ describe("getActiveTimer", () => {
 
     expect(db.activeTimer.findUnique).toHaveBeenCalledWith({
       where: { userId: "specific-user" },
+      include: { task: { select: { title: true } } },
     });
   });
 });


### PR DESCRIPTION
Fixes #12

Two causes, per the issue audit:

1. **Stale test, not a bug**: `getActiveTimer` includes the task title since the navbar timer (#37). The test asserted the old call shape — assertion updated.
2. **Real gap**: `updateTimeEntry` / `deleteTimeEntry` never checked the parent task's `deletedAt`. Both now look up the task with `deletedAt: null` and return `NOT_FOUND` when it is soft-deleted — same pattern the read/create paths already use (CONTEXT.md invariant 6: soft-deleted rows filtered from every query).

Test suite: 119/119 green. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)