### PR TITLE
fix: stop cascades at descendants already in target state

### DIFF
--- a/docs/adr/0018-policy-based-hierarchy-transitions.md
+++ b/docs/adr/0018-policy-based-hierarchy-transitions.md
@@ -5,13 +5,17 @@
 **Decision:** Extract validation and plan-building into `lib/services/taskHierarchyPolicy.ts`. Each operation is a `TransitionKind`. `validateTransition()` checks ancestor legality; `buildTransitionPlan()` returns a `TransitionPlan` with IDs and values for `completedAt`, `archivedAt`, `deletedAt`. Service functions call validate → build plan → execute plan.
 
 **Rules per operation:**
-| Operation | Downward cascade | Ancestor forbidden states | Ancestor propagation |
-|-----------|-----------------|--------------------------|---------------------|
-| COMPLETE | All descendants | deleted, archived, completion gap | None |
-| UNCOMPLETE | None | deleted, archived, completion gap | Uncomplete contiguous completed ancestors |
-| ARCHIVE | All descendants | deleted, archived | None |
-| UNARCHIVE | None | deleted, archive gap | Unarchive contiguous archived ancestors |
-| DELETE | All descendants (incl. archived) | deleted | None |
-| UNDELETE | None | deletion gap | Undelete contiguous deleted ancestors |
+| Operation | Self forbidden states | Downward cascade | Ancestor forbidden states | Ancestor propagation |
+|-----------|----------------------|-----------------|--------------------------|---------------------|
+| COMPLETE | deleted, archived, completed | Descendants, stop rule | deleted, archived, completion gap | None |
+| UNCOMPLETE | deleted, archived, not completed | None | deleted, archived, completion gap | Uncomplete contiguous completed ancestors |
+| ARCHIVE | deleted, archived | Descendants, stop rule | deleted, archived | None |
+| UNARCHIVE | deleted, not archived | None | deleted, archive gap | Unarchive contiguous archived ancestors |
+| DELETE | deleted | Descendants (incl. archived), stop rule | deleted | None |
+| UNDELETE | not deleted | None | deletion gap | Undelete contiguous deleted ancestors |
 
-**Consequences:** Adding a new hierarchy operation means adding a validate + build function pair and a `TransitionKind` entry. Service functions follow a uniform pattern: load task → load ancestors → validate → collect descendants (if needed) → build plan → execute plan.
+**Self-state (#15):** the task's own flags are judged in `validateSelfState()`, first step of `validateTransition()` — one source of truth. Service fetch where-clauses remain only for visibility and NOT_FOUND masking.
+
+**Stop rule (#44):** a downward cascade stops at the first descendant already in the target state — its date is not re-stamped and the walk does not continue below it. State dates are estimation evidence; the no-gaps invariant (CONTEXT.md invariant 5) guarantees everything below the stop is already in the target state, so nothing is missed. Guarded by `createTask` refusing deleted, archived, or completed parents.
+
+**Consequences:** Adding a new hierarchy operation means adding a validate + build function pair and a `TransitionKind` entry. Service functions follow a uniform pattern: load task → load ancestors → validate → collect descendant nodes (if needed) → build plan → execute plan. Downward plans receive descendant nodes (with the three state flags), not bare ids — the policy decides what to touch, the service only fetches and executes.

--- a/lib/services/task.service.ts
+++ b/lib/services/task.service.ts
@@ -8,6 +8,7 @@ import {
 import {
   validateTransition,
   buildTransitionPlan,
+  type LineageNode,
   type TransitionPlan,
 } from "./taskHierarchyPolicy";
 
@@ -24,26 +25,34 @@ type AncestorRow = {
 };
 
 /**
- * BFS to collect a task and all its descendants within a project.
+ * BFS to collect a task and all its descendants within a project, with the
+ * three state flags so the transition policy can decide what to touch.
  * Only traverses non-deleted and non-archived tasks.
  * Accepts an optional `db` client to run inside an interactive transaction.
  */
-async function collectDescendantIds(
+async function collectDescendantNodes(
   taskId: string,
   projectId: string,
   db: DbClient = client,
   includeArchived = false,
   includeDeleted = false,
-): Promise<string[]> {
+): Promise<LineageNode[]> {
   const projectTasks = await db.task.findMany({
     where: {
       projectId,
       deletedAt: includeDeleted ? undefined : null,
       archivedAt: includeArchived ? undefined : null,
     },
-    select: { id: true, parentId: true },
+    select: {
+      id: true,
+      parentId: true,
+      completedAt: true,
+      archivedAt: true,
+      deletedAt: true,
+    },
   });
 
+  const byId = new Map(projectTasks.map((t) => [t.id, t]));
   const childrenMap = new Map<string, string[]>();
   for (const t of projectTasks) {
     if (t.parentId) {
@@ -52,15 +61,16 @@ async function collectDescendantIds(
     }
   }
 
-  const allIds: string[] = [];
+  const nodes: LineageNode[] = [];
   const queue = [taskId];
   while (queue.length > 0) {
     const current = queue.shift()!;
-    allIds.push(current);
+    const node = byId.get(current);
+    if (node) nodes.push(node);
     const children = childrenMap.get(current) ?? [];
     queue.push(...children);
   }
-  return allIds;
+  return nodes;
 }
 
 async function executePlan(plan: TransitionPlan, tx: DbClient): Promise<void> {
@@ -277,7 +287,7 @@ export function deleteTask({
         );
       }
 
-      const descendantIds = await collectDescendantIds(
+      const descendants = await collectDescendantNodes(
         taskId,
         task.projectId,
         tx,
@@ -285,7 +295,7 @@ export function deleteTask({
       );
 
       const activeTimer = await tx.activeTimer.findFirst({
-        where: { taskId: { in: descendantIds } },
+        where: { taskId: { in: descendants.map((d) => d.id) } },
       });
 
       if (activeTimer) {
@@ -295,17 +305,12 @@ export function deleteTask({
         );
       }
 
-      const plan = buildTransitionPlan(
-        "DELETE",
-        task,
-        ancestors,
-        descendantIds,
-      );
+      const plan = buildTransitionPlan("DELETE", task, ancestors, descendants);
       await executePlan(plan, tx);
 
       return createSuccessResponseWithData({
         id: taskId,
-        deletedCount: descendantIds.length,
+        deletedCount: plan.setDeletedAt.ids.length,
       });
     });
   }, "Failed to delete task");
@@ -319,10 +324,10 @@ export function hasActiveDescendants({ taskId }: { taskId: string }) {
     });
     if (!task) return createServiceErrorResponse("NOT_FOUND", "Task not found");
 
-    const descendantIds = await collectDescendantIds(taskId, task.projectId);
+    const descendants = await collectDescendantNodes(taskId, task.projectId);
 
     const activeTimer = await client.activeTimer.findFirst({
-      where: { taskId: { in: descendantIds } },
+      where: { taskId: { in: descendants.map((d) => d.id) } },
     });
     return createSuccessResponseWithData(!!activeTimer);
   }, "Failed to check active timers for task");
@@ -369,14 +374,14 @@ export function completeTask({
         );
       }
 
-      const descendantIds = await collectDescendantIds(
+      const descendants = await collectDescendantNodes(
         taskId,
         task.projectId,
         tx,
       );
 
       const activeTimer = await tx.activeTimer.findFirst({
-        where: { taskId: { in: descendantIds } },
+        where: { taskId: { in: descendants.map((d) => d.id) } },
       });
       if (activeTimer) {
         return createServiceErrorResponse(
@@ -389,13 +394,13 @@ export function completeTask({
         "COMPLETE",
         task,
         ancestors,
-        descendantIds,
+        descendants,
       );
       await executePlan(plan, tx);
 
       return createSuccessResponseWithData({
         id: taskId,
-        completedCount: descendantIds.length,
+        completedCount: plan.setCompletedAt.ids.length,
       });
     });
   }, "Failed to complete task");
@@ -498,14 +503,14 @@ export function archiveTask({
         );
       }
 
-      const descendantIds = await collectDescendantIds(
+      const descendants = await collectDescendantNodes(
         taskId,
         task.projectId,
         tx,
       );
 
       const activeTimer = await tx.activeTimer.findFirst({
-        where: { taskId: { in: descendantIds } },
+        where: { taskId: { in: descendants.map((d) => d.id) } },
       });
       if (activeTimer) {
         return createServiceErrorResponse(
@@ -518,13 +523,13 @@ export function archiveTask({
         "ARCHIVE",
         task,
         ancestors,
-        descendantIds,
+        descendants,
       );
       await executePlan(plan, tx);
 
       return createSuccessResponseWithData({
         id: taskId,
-        archivedCount: descendantIds.length,
+        archivedCount: plan.setArchivedAt.ids.length,
       });
     });
   }, "Failed to archive task");

--- a/lib/services/taskHierarchyPolicy.ts
+++ b/lib/services/taskHierarchyPolicy.ts
@@ -215,37 +215,77 @@ function validateUndelete(ancestors: LineageNode[]): ValidationResult {
 // ─── Plan Building ─────────────────────────────────────────────────────────────
 
 /**
+ * Downward-cascade stop rule (#44): a descendant already in the target state
+ * keeps its original date — it is not re-stamped, and the walk does not
+ * continue below it. The no-gaps invariant (CONTEXT.md invariant 5) means
+ * everything below it is already in the target state, so nothing is missed.
+ * The dates are estimation evidence; overwriting them destroys it.
+ */
+function pruneCascade(
+  taskId: string,
+  descendants: LineageNode[],
+  inTargetState: (n: LineageNode) => boolean,
+): string[] {
+  const byId = new Map(descendants.map((n) => [n.id, n]));
+  const childrenMap = new Map<string, string[]>();
+  for (const n of descendants) {
+    if (n.parentId) {
+      if (!childrenMap.has(n.parentId)) childrenMap.set(n.parentId, []);
+      childrenMap.get(n.parentId)!.push(n.id);
+    }
+  }
+
+  const ids: string[] = [];
+  const queue = [taskId];
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    const node = byId.get(current);
+    if (!node || inTargetState(node)) continue; // stop: keep its date, skip its subtree
+    ids.push(current);
+    queue.push(...(childrenMap.get(current) ?? []));
+  }
+  return ids;
+}
+
+/**
  * Build the set of mutations required for a hierarchy transition.
  *
  * `task` is the target. `ancestors` ordered nearest-parent → root.
- * `descendantIds` is the list of task + descendant IDs (only needed for downward cascades).
+ * `descendants` is the task + descendant nodes (only needed for downward
+ * cascades); downward plans prune via the stop rule above.
  */
 export function buildTransitionPlan(
   kind: TransitionKind,
   task: LineageNode,
   ancestors: LineageNode[],
-  descendantIds: string[] = [],
+  descendants: LineageNode[] = [],
 ): TransitionPlan {
   switch (kind) {
     case "COMPLETE":
-      return buildCompletePlan(descendantIds);
+      return buildCompletePlan(task, descendants);
     case "UNCOMPLETE":
       return buildUncompletePlan(task, ancestors);
     case "ARCHIVE":
-      return buildArchivePlan(descendantIds);
+      return buildArchivePlan(task, descendants);
     case "UNARCHIVE":
       return buildUnarchivePlan(task, ancestors);
     case "DELETE":
-      return buildDeletePlan(descendantIds);
+      return buildDeletePlan(task, descendants);
     case "UNDELETE":
       return buildUndeletePlan(task, ancestors);
   }
 }
 
-function buildCompletePlan(descendantIds: string[]): TransitionPlan {
+function buildCompletePlan(
+  task: LineageNode,
+  descendants: LineageNode[],
+): TransitionPlan {
   return {
     ...EMPTY_PLAN,
-    setCompletedAt: { ids: descendantIds, value: new Date() },
+    setCompletedAt: {
+      ids: pruneCascade(task.id, descendants, (n) => !!n.completedAt),
+      value: new Date(),
+    },
   };
 }
 
@@ -268,10 +308,16 @@ function buildUncompletePlan(
   };
 }
 
-function buildArchivePlan(descendantIds: string[]): TransitionPlan {
+function buildArchivePlan(
+  task: LineageNode,
+  descendants: LineageNode[],
+): TransitionPlan {
   return {
     ...EMPTY_PLAN,
-    setArchivedAt: { ids: descendantIds, value: new Date() },
+    setArchivedAt: {
+      ids: pruneCascade(task.id, descendants, (n) => !!n.archivedAt),
+      value: new Date(),
+    },
   };
 }
 
@@ -294,10 +340,16 @@ function buildUnarchivePlan(
   };
 }
 
-function buildDeletePlan(descendantIds: string[]): TransitionPlan {
+function buildDeletePlan(
+  task: LineageNode,
+  descendants: LineageNode[],
+): TransitionPlan {
   return {
     ...EMPTY_PLAN,
-    setDeletedAt: { ids: descendantIds, value: new Date() },
+    setDeletedAt: {
+      ids: pruneCascade(task.id, descendants, (n) => !!n.deletedAt),
+      value: new Date(),
+    },
   };
 }
 

--- a/tests/unit/services/taskHierarchyPolicy.test.ts
+++ b/tests/unit/services/taskHierarchyPolicy.test.ts
@@ -360,11 +360,24 @@ describe("validateTransition — UNDELETE", () => {
 describe("buildTransitionPlan — COMPLETE", () => {
   it("completes all descendants", () => {
     const task = node("t1", null);
-    const plan = buildTransitionPlan("COMPLETE", task, [], ["t1", "t2", "t3"]);
+    const descendants = [task, node("t2", "t1"), node("t3", "t2")];
+    const plan = buildTransitionPlan("COMPLETE", task, [], descendants);
     expect(plan.setCompletedAt.ids).toEqual(["t1", "t2", "t3"]);
     expect(plan.setCompletedAt.value).toBeInstanceOf(Date);
     expect(plan.setArchivedAt.ids).toEqual([]);
     expect(plan.setDeletedAt.ids).toEqual([]);
+  });
+
+  it("stops at an already-completed descendant and keeps its date", () => {
+    const task = node("t1", null);
+    const descendants = [
+      task,
+      node("t2", "t1", { completedAt: now }), // finished earlier — keep its date
+      node("t3", "t1"),
+      node("t4", "t2", { completedAt: now }), // below the stop — not walked
+    ];
+    const plan = buildTransitionPlan("COMPLETE", task, [], descendants);
+    expect(plan.setCompletedAt.ids).toEqual(["t1", "t3"]);
   });
 });
 
@@ -406,9 +419,22 @@ describe("buildTransitionPlan — UNCOMPLETE", () => {
 describe("buildTransitionPlan — ARCHIVE", () => {
   it("archives all descendants", () => {
     const task = node("t1", null);
-    const plan = buildTransitionPlan("ARCHIVE", task, [], ["t1", "t2"]);
+    const descendants = [task, node("t2", "t1")];
+    const plan = buildTransitionPlan("ARCHIVE", task, [], descendants);
     expect(plan.setArchivedAt.ids).toEqual(["t1", "t2"]);
     expect(plan.setArchivedAt.value).toBeInstanceOf(Date);
+  });
+
+  it("stops at an already-archived descendant and keeps its date", () => {
+    const task = node("t1", null);
+    const descendants = [
+      task,
+      node("t2", "t1", { archivedAt: now }), // archived earlier — keep its date
+      node("t3", "t1"),
+      node("t4", "t2", { archivedAt: now }), // below the stop — not walked
+    ];
+    const plan = buildTransitionPlan("ARCHIVE", task, [], descendants);
+    expect(plan.setArchivedAt.ids).toEqual(["t1", "t3"]);
   });
 });
 
@@ -447,11 +473,28 @@ describe("buildTransitionPlan — UNARCHIVE", () => {
 // ─── buildTransitionPlan: DELETE ───────────────────────────────────────────────
 
 describe("buildTransitionPlan — DELETE", () => {
-  it("deletes all descendants", () => {
+  it("deletes all descendants including archived ones", () => {
     const task = node("t1", null);
-    const plan = buildTransitionPlan("DELETE", task, [], ["t1", "t2", "t3"]);
+    const descendants = [
+      task,
+      node("t2", "t1", { archivedAt: now }), // archived but not deleted — still deleted
+      node("t3", "t2"),
+    ];
+    const plan = buildTransitionPlan("DELETE", task, [], descendants);
     expect(plan.setDeletedAt.ids).toEqual(["t1", "t2", "t3"]);
     expect(plan.setDeletedAt.value).toBeInstanceOf(Date);
+  });
+
+  it("stops at an already-deleted descendant and keeps its date", () => {
+    const task = node("t1", null);
+    const descendants = [
+      task,
+      node("t2", "t1", { deletedAt: now }), // deleted earlier — keep its date
+      node("t3", "t1"),
+      node("t4", "t2", { deletedAt: now }), // below the stop — not walked
+    ];
+    const plan = buildTransitionPlan("DELETE", task, [], descendants);
+    expect(plan.setDeletedAt.ids).toEqual(["t1", "t3"]);
   });
 });
 


### PR DESCRIPTION
Fixes #44

Stacked on #43 — retarget to main-vibe once #43 merges.

## Problem

Completing a task stamped today's date on ALL descendants — a child finished on Tuesday lost its date when the parent completed on Friday. These dates are estimation evidence (analysis #26, events #23 need the true ones). ARCHIVE and DELETE only escaped by accident: their descendant query filtered archived/deleted out implicitly.

## Fix

The stop rule now lives explicitly in the policy: `pruneCascade()` in `taskHierarchyPolicy.ts` walks the subtree and stops at the first descendant already in the target state — no re-stamp, no walk below it. Applied to COMPLETE, ARCHIVE, DELETE plans.

Safe because the no-gaps guarantee holds (verified in code): `createTask` refuses deleted, archived AND completed parents; `updateTask` cannot reparent; upward repairs (uncomplete/unarchive/undelete) always restore contiguously. So everything below a stopped descendant is already in the target state.

Per ADR-0018's split (policy decides, service fetches/executes): `collectDescendantIds` → `collectDescendantNodes`, giving plans the three state flags instead of bare ids. The active-timer guard still covers the full unpruned subtree. `completedCount`/`archivedCount`/`deletedCount` now count only newly stamped tasks.

ADR-0018 updated: self-state column (from #43) + stop rule row/notes — the one docs exception agreed for this PR.

## Tests

3 new stop-rule cases + plan tests moved to node fixtures. 131 pass, typecheck clean; the 3 remaining failures are pre-existing (#12, fixed in PR #42, not merged yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)