### PR TITLE
refactor: ship activeDescendantStartedAt across the server-client seam

### DIFF
--- a/app/s/project/[project-id]/tasks.tsx
+++ b/app/s/project/[project-id]/tasks.tsx
@@ -20,7 +20,7 @@ import { Dispatch, SetStateAction, useState } from "react";
 import IconButton from "../../../../components/iconButton";
 import { Subheading } from "@/components/heading";
 import { SecondaryText } from "@/components/text";
-import { formatTime, getActiveDescendantStartedAt } from "@/lib/util";
+import { formatTime } from "@/lib/util";
 import { useElapsedTimer } from "@/lib/hooks";
 import {
   startActiveTimerAction,
@@ -84,11 +84,7 @@ export default function Tasks({
   const { showToast } = useToast();
 
   const timerStartedAt =
-    task.status === "IN_PROGRESS"
-      ? task.activeTimerStartedAt
-      : task.hasActiveDescendant
-        ? getActiveDescendantStartedAt(task)
-        : null;
+    task.activeTimerStartedAt ?? task.activeDescendantStartedAt;
 
   const elapsed = useElapsedTimer(timerStartedAt);
   const displayTotal = task.totalTimeSpent + elapsed;

--- a/lib/schema/task.ts
+++ b/lib/schema/task.ts
@@ -49,6 +49,7 @@ export type TaskNode = Prisma.TaskGetPayload<{
   children: TaskNode[];
   status: TaskStatus;
   hasActiveDescendant: boolean;
+  activeDescendantStartedAt: Date | null;
   totalTimeSpent: number; // seconds
   activeTimerStartedAt: Date | null;
   sumOfChildrenEstimates: number; // minutes

--- a/lib/services/project.service.ts
+++ b/lib/services/project.service.ts
@@ -282,6 +282,7 @@ export function getProjectTaskTree({
         children: [],
         status: "OPEN",
         hasActiveDescendant: false,
+        activeDescendantStartedAt: null,
         totalTimeSpent,
         activeTimerStartedAt:
           task.id === activeTaskId ? activeTimerStartedAt : null,
@@ -309,9 +310,14 @@ export function getProjectTaskTree({
         : node.id === activeTaskId
           ? "IN_PROGRESS"
           : "OPEN";
-      node.hasActiveDescendant = node.children.some(
+      const activeChild = node.children.find(
         (c) => c.status === "IN_PROGRESS" || c.hasActiveDescendant,
       );
+      node.hasActiveDescendant = activeChild !== undefined;
+      node.activeDescendantStartedAt = activeChild
+        ? (activeChild.activeTimerStartedAt ??
+          activeChild.activeDescendantStartedAt)
+        : null;
       node.totalTimeSpent = node.children.reduce(
         (sum, c) => sum + c.totalTimeSpent,
         node.totalTimeSpent,
@@ -360,6 +366,7 @@ function buildTaskNodeTree(flatTasks: TaskWithIncludes[]): TaskNode[] {
       children: [],
       status: task.completedAt ? "DONE" : "OPEN",
       hasActiveDescendant: false,
+      activeDescendantStartedAt: null,
       totalTimeSpent,
       activeTimerStartedAt: null,
       sumOfChildrenEstimates: 0,

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -1,5 +1,3 @@
-import { TaskNode } from "./schema/task";
-
 export type ApiErrorCode =
   | "ZOD_VALIDATION_ERROR"
   | "INTERNAL_SERVER_ERROR"
@@ -103,29 +101,4 @@ export function formatTime(
   }
 }
 
-export function getActiveDescendantElapsed(task: TaskNode): number {
-  if (task.activeTimerStartedAt) {
-    const start = new Date(task.activeTimerStartedAt).getTime();
-    return Math.floor((Date.now() - start) / 1000);
-  }
 
-  for (const child of task.children) {
-    const elapsed = getActiveDescendantElapsed(child);
-    if (elapsed > 0) return elapsed;
-  }
-
-  return 0;
-}
-
-export function getActiveDescendantStartedAt(task: TaskNode): Date | null {
-  if (task.activeTimerStartedAt) {
-    return task.activeTimerStartedAt;
-  }
-
-  for (const child of task.children) {
-    const startedAt = getActiveDescendantStartedAt(child);
-    if (startedAt) return startedAt;
-  }
-
-  return null;
-}


### PR DESCRIPTION
## What

Nodes in the project task tree now carry `activeDescendantStartedAt: Date | null`, filled during the post-order pass the server already runs. The client timer read in `tasks.tsx` becomes a plain field access.

Deleted from `lib/util.ts`:
- `getActiveDescendantStartedAt` — its only caller is gone
- `getActiveDescendantElapsed` — dead code, zero callers

## Why

Seam leak: the server held the active timer's start Date as one variable (`project.service.ts:271`) but shipped only `hasActiveDescendant: boolean`. Every ancestor row of the running task re-walked its subtree on every render to recover the Date — tree-traversal knowledge duplicated on the client, drifting silently if the server's activity rule ever changes.

Design decision (Felix): per-node field, not a top-level response field — "one timer per **user**" is domain truth, but "one timer per **tree**" is a current limitation (multiplayer sub-tasks can be owned by other users). The seam encodes the truth, not the limitation. When multiple timers land, the which-date-wins rule has a single home in the server's post-order pass.

Matches candidate 1 (seam part) of the 2026-07-10 architecture review.

## Verification

- `tsc --noEmit` clean
- `npm test`: 116 passed, 3 failed — same 3 fail on the base branch without these changes (activeTask/timeEntry service tests, pre-existing)
- eslint on changed files: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)