### PR TITLE
refactor: derive activeDescendantStartedAt in tree build

### DIFF
--- a/app/s/project/[project-id]/tasks.tsx
+++ b/app/s/project/[project-id]/tasks.tsx
@@ -20,7 +20,7 @@ import { Dispatch, SetStateAction, useState } from "react";
 import IconButton from "../../../../components/iconButton";
 import { Subheading } from "@/components/heading";
 import { SecondaryText } from "@/components/text";
-import { formatTime, getActiveDescendantStartedAt } from "@/lib/util";
+import { formatTime } from "@/lib/util";
 import { useElapsedTimer } from "@/lib/hooks";
 import {
   startActiveTimerAction,
@@ -83,14 +83,9 @@ export default function Tasks({
   const [loading, setLoading] = useState(false);
   const { showToast } = useToast();
 
-  const timerStartedAt =
-    task.status === "IN_PROGRESS"
-      ? task.activeTimerStartedAt
-      : task.hasActiveDescendant
-        ? getActiveDescendantStartedAt(task)
-        : null;
-
-  const elapsed = useElapsedTimer(timerStartedAt);
+  const elapsed = useElapsedTimer(
+    task.activeTimerStartedAt ?? task.activeDescendantStartedAt,
+  );
   const displayTotal = task.totalTimeSpent + elapsed;
 
   async function handleCompleteTask(completeTaskParams: { taskId: string }) {

--- a/lib/schema/task.ts
+++ b/lib/schema/task.ts
@@ -51,6 +51,7 @@ export type TaskNode = Prisma.TaskGetPayload<{
   hasActiveDescendant: boolean;
   totalTimeSpent: number; // seconds
   activeTimerStartedAt: Date | null;
+  activeDescendantStartedAt: Date | null;
   sumOfChildrenEstimates: number; // minutes
   hasEstimateOverflow: boolean; // true if sumOfChildrenEstimates > estimate
   addSubtaskEstimates: boolean;

--- a/lib/services/project.service.ts
+++ b/lib/services/project.service.ts
@@ -285,6 +285,7 @@ export function getProjectTaskTree({
         totalTimeSpent,
         activeTimerStartedAt:
           task.id === activeTaskId ? activeTimerStartedAt : null,
+        activeDescendantStartedAt: null,
         sumOfChildrenEstimates: 0,
         hasEstimateOverflow: false,
       });
@@ -309,9 +310,16 @@ export function getProjectTaskTree({
         : node.id === activeTaskId
           ? "IN_PROGRESS"
           : "OPEN";
-      node.hasActiveDescendant = node.children.some(
+
+      const activeDescendant = node.children.find(
         (c) => c.status === "IN_PROGRESS" || c.hasActiveDescendant,
       );
+      node.hasActiveDescendant = activeDescendant !== undefined;
+      node.activeDescendantStartedAt = activeDescendant
+        ? (activeDescendant.activeDescendantStartedAt ??
+          activeDescendant.activeTimerStartedAt)
+        : null;
+
       node.totalTimeSpent = node.children.reduce(
         (sum, c) => sum + c.totalTimeSpent,
         node.totalTimeSpent,
@@ -362,6 +370,7 @@ function buildTaskNodeTree(flatTasks: TaskWithIncludes[]): TaskNode[] {
       hasActiveDescendant: false,
       totalTimeSpent,
       activeTimerStartedAt: null,
+      activeDescendantStartedAt: null,
       sumOfChildrenEstimates: 0,
       hasEstimateOverflow: false,
     });

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -1,5 +1,3 @@
-import { TaskNode } from "./schema/task";
-
 export type ApiErrorCode =
   | "ZOD_VALIDATION_ERROR"
   | "INTERNAL_SERVER_ERROR"
@@ -101,31 +99,4 @@ export function formatTime(
     if (!leading_zeros && hours === 0) return `${minutes}:${pad(seconds)}`;
     return `${leading_zeros ? pad(hours) : hours}:${pad(minutes)}:${pad(seconds)}`;
   }
-}
-
-export function getActiveDescendantElapsed(task: TaskNode): number {
-  if (task.activeTimerStartedAt) {
-    const start = new Date(task.activeTimerStartedAt).getTime();
-    return Math.floor((Date.now() - start) / 1000);
-  }
-
-  for (const child of task.children) {
-    const elapsed = getActiveDescendantElapsed(child);
-    if (elapsed > 0) return elapsed;
-  }
-
-  return 0;
-}
-
-export function getActiveDescendantStartedAt(task: TaskNode): Date | null {
-  if (task.activeTimerStartedAt) {
-    return task.activeTimerStartedAt;
-  }
-
-  for (const child of task.children) {
-    const startedAt = getActiveDescendantStartedAt(child);
-    if (startedAt) return startedAt;
-  }
-
-  return null;
 }


### PR DESCRIPTION
Felix's own implementation (compare closed #47). Field derived once in buildTaskTree (deepest-active-descendant wins); UI reads `activeTimerStartedAt ?? activeDescendantStartedAt`; dead tree-walk helpers removed from lib/util.ts.

Verified: tsc clean, tests green except the 3 pre-existing activeTask/timeEntry failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)