### PR TITLE
refactor: self timer wins in activeDescendantStartedAt derivation

### DIFF
--- a/lib/services/project.service.ts
+++ b/lib/services/project.service.ts
@@ -315,9 +315,11 @@ export function getProjectTaskTree({
         (c) => c.status === "IN_PROGRESS" || c.hasActiveDescendant,
       );
       node.hasActiveDescendant = activeDescendant !== undefined;
+      // Shallowest wins: a shared subtree's viewer can't see ancestors,
+      // so the subtree root's own timer must take priority over deeper ones.
       node.activeDescendantStartedAt = activeDescendant
-        ? (activeDescendant.activeDescendantStartedAt ??
-          activeDescendant.activeTimerStartedAt)
+        ? (activeDescendant.activeTimerStartedAt ??
+          activeDescendant.activeDescendantStartedAt)
         : null;
 
       node.totalTimeSpent = node.children.reduce(


### PR DESCRIPTION
Flips the `??` order from deepest-wins to shallowest-wins. Behaviorally identical today (single active timer), but with future task sharing a sharee can't see ancestors, so the subtree root's own timer must win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)