### PR TITLE
fix: migrate remaining inline errors to toasts (#29)

### DIFF
--- a/app/s/project/[project-id]/setDefaultButton.tsx
+++ b/app/s/project/[project-id]/setDefaultButton.tsx
@@ -33,9 +33,9 @@ export default function SetDefaultButton({
 
     setLoading(false);
 
-    if (result.success) {
-      setShowConfirm(false);
-    } else {
+    setShowConfirm(false);
+
+    if (!result.success) {
       showToast(
         <ErrorToast
           title="Standardprojekt konnte nicht gesetzt werden"

--- a/app/s/project/[project-id]/setDefaultButton.tsx
+++ b/app/s/project/[project-id]/setDefaultButton.tsx
@@ -10,6 +10,7 @@ import {
   AlertTitle,
 } from "@/components/alert";
 import { updateProjectAction } from "@/lib/actions/project.actions";
+import { ErrorToast, useToast } from "@/lib/notification/toastProvider";
 
 export default function SetDefaultButton({
   projectId,
@@ -20,11 +21,10 @@ export default function SetDefaultButton({
 }) {
   const [showConfirm, setShowConfirm] = useState(false);
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const { showToast } = useToast();
 
   async function handleSetDefault() {
     setLoading(true);
-    setError(null);
 
     const result = await updateProjectAction({
       id: projectId,
@@ -36,7 +36,12 @@ export default function SetDefaultButton({
     if (result.success) {
       setShowConfirm(false);
     } else {
-      setError(result.error.message);
+      showToast(
+        <ErrorToast
+          title="Standardprojekt konnte nicht gesetzt werden"
+          description={result.error.message}
+        />,
+      );
     }
   }
 
@@ -51,21 +56,12 @@ export default function SetDefaultButton({
         <StarIcon className="w-5 h-5 text-zinc-500 dark:text-zinc-400" />
       </button>
 
-      <Alert
-        open={showConfirm}
-        onClose={() => {
-          setShowConfirm(false);
-          setError(null);
-        }}
-      >
+      <Alert open={showConfirm} onClose={() => setShowConfirm(false)}>
         <AlertTitle>„{projectName}" als Standardprojekt festlegen?</AlertTitle>
         <AlertDescription>
           Dieses Projekt wird als Startseite angezeigt. Das bisherige
           Standardprojekt wird zurückgesetzt.
         </AlertDescription>
-        {error && (
-          <p className="mt-2 text-sm text-red-600 dark:text-red-400">{error}</p>
-        )}
         <AlertActions>
           <Button
             plain

--- a/app/s/project/[project-id]/settings/deleteProjectSection.tsx
+++ b/app/s/project/[project-id]/settings/deleteProjectSection.tsx
@@ -35,6 +35,9 @@ export default function DeleteProjectSection({
       router.push("/s/main");
     } else {
       setLoading(false);
+      // Close the dialog first: while it is open the page outside is inert,
+      // so a toast behind it could not be dismissed or read.
+      setShowConfirm(false);
       showToast(
         <ErrorToast
           title="Projekt konnte nicht gelöscht werden"

--- a/app/s/project/[project-id]/settings/deleteProjectSection.tsx
+++ b/app/s/project/[project-id]/settings/deleteProjectSection.tsx
@@ -12,6 +12,7 @@ import {
 import { deleteProjectAction } from "@/lib/actions/project.actions";
 import { Subheading } from "@/components/heading";
 import { SecondaryText } from "@/components/text";
+import { ErrorToast, useToast } from "@/lib/notification/toastProvider";
 
 export default function DeleteProjectSection({
   projectId,
@@ -22,12 +23,11 @@ export default function DeleteProjectSection({
 }) {
   const [showConfirm, setShowConfirm] = useState(false);
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
   const router = useRouter();
+  const { showToast } = useToast();
 
   async function handleDelete() {
     setLoading(true);
-    setError(null);
 
     const result = await deleteProjectAction(projectId);
 
@@ -35,7 +35,12 @@ export default function DeleteProjectSection({
       router.push("/s/main");
     } else {
       setLoading(false);
-      setError(result.error.message);
+      showToast(
+        <ErrorToast
+          title="Projekt konnte nicht gelöscht werden"
+          description={result.error.message}
+        />,
+      );
     }
   }
 
@@ -51,11 +56,6 @@ export default function DeleteProjectSection({
         <Button color="red" onClick={() => setShowConfirm(true)}>
           Projekt löschen
         </Button>
-        {error && (
-          <span className="text-sm text-red-600 dark:text-red-400">
-            {error}
-          </span>
-        )}
       </div>
 
       <Alert open={showConfirm} onClose={() => setShowConfirm(false)}>

--- a/app/s/project/[project-id]/settings/updateProjectForm.tsx
+++ b/app/s/project/[project-id]/settings/updateProjectForm.tsx
@@ -13,6 +13,7 @@ import { Input } from "@/components/input";
 import { Textarea } from "@/components/textarea";
 import { SwitchField, Switch } from "@/components/switch";
 import { updateProjectAction } from "@/lib/actions/project.actions";
+import { ErrorToast, useToast } from "@/lib/notification/toastProvider";
 
 export default function UpdateProjectForm({
   projectId,
@@ -29,8 +30,8 @@ export default function UpdateProjectForm({
   const [description, setDescription] = useState(initialDescription);
   const [isDefault, setIsDefault] = useState(initialIsDefault);
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
+  const { showToast } = useToast();
 
   // Tracks the last-saved values so isPristine stays correct after saves
   const [baseline, setBaseline] = useState({
@@ -47,11 +48,15 @@ export default function UpdateProjectForm({
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     if (name.trim().length < 2) {
-      setError("Der Projektname muss mindestens 2 Zeichen lang sein.");
+      showToast(
+        <ErrorToast
+          title="Ungültiger Projektname"
+          description="Der Projektname muss mindestens 2 Zeichen lang sein."
+        />,
+      );
       return;
     }
     setLoading(true);
-    setError(null);
     setSaved(false);
 
     const trimmedName = name.trim();
@@ -72,7 +77,12 @@ export default function UpdateProjectForm({
       setSaved(true);
       setTimeout(() => setSaved(false), 3000);
     } else {
-      setError(result.error.message);
+      showToast(
+        <ErrorToast
+          title="Projekt konnte nicht gespeichert werden"
+          description={result.error.message}
+        />,
+      );
     }
   }
 
@@ -119,11 +129,6 @@ export default function UpdateProjectForm({
             {saved && (
               <span className="text-sm text-green-600 dark:text-green-400">
                 Gespeichert
-              </span>
-            )}
-            {error && (
-              <span className="text-sm text-red-600 dark:text-red-400">
-                {error}
               </span>
             )}
           </div>


### PR DESCRIPTION
Closes #29.

updateProjectForm, deleteProjectSection, setDefaultButton now surface errors via ErrorToast (pattern from create-project-form). Inline error state and red spans removed; "Gespeichert" success indicator kept (ticket scope = errors).

Review finding fixed in second commit: confirm dialogs now close before the error toast fires — an open Headless UI dialog makes outside content inert, so the toast would have been unclickable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)