### PR TITLE
feat: emit TAGS_CHANGED task event

### DIFF
--- a/lib/services/task.service.ts
+++ b/lib/services/task.service.ts
@@ -1,5 +1,7 @@
+import { TaskEventType } from "@prisma/client";
 import client from "@/lib/prisma";
 import { CreateTaskParams, UpdateTaskParams } from "../schema/task";
+import { emitEvent } from "./event.service";
 import {
   createServiceErrorResponse,
   createSuccessResponseWithData,
@@ -222,24 +224,61 @@ export function updateTask({
       );
     }
 
-    const updatedTask = await client.task.update({
-      where: { id: updateTaskParams.id },
-      data: {
-        title: updateTaskParams.title,
-        description: updateTaskParams.description,
-        estimate: updateTaskParams.estimate,
-        ...(updateTaskParams.tagIds !== null
-          ? {
-              taskTags: {
-                deleteMany: { userId },
-                create: updateTaskParams.tagIds.map((tagId) => ({
-                  tag: { connect: { id: tagId } },
-                  user: { connect: { id: userId } },
-                })),
-              },
-            }
-          : {}),
-      },
+    // null means "leave tags untouched"; an array (even empty) edits the set.
+    const tagIds = updateTaskParams.tagIds;
+
+    const updatedTask = await client.$transaction(async (tx) => {
+      // Snapshot the tag set before the update so a TAGS_CHANGED event can record
+      // before/after. Tags are per-user, so scope the read to this actor.
+      const oldTagIds =
+        tagIds !== null
+          ? (
+              await tx.taskTag.findMany({
+                where: { taskId: updateTaskParams.id, userId },
+                select: { tagId: true },
+              })
+            ).map((t) => t.tagId)
+          : [];
+
+      const updated = await tx.task.update({
+        where: { id: updateTaskParams.id },
+        data: {
+          title: updateTaskParams.title,
+          description: updateTaskParams.description,
+          estimate: updateTaskParams.estimate,
+          ...(tagIds !== null
+            ? {
+                taskTags: {
+                  deleteMany: { userId },
+                  create: tagIds.map((tagId) => ({
+                    tag: { connect: { id: tagId } },
+                    user: { connect: { id: userId } },
+                  })),
+                },
+              }
+            : {}),
+        },
+      });
+
+      // Emit only on a real change: re-submitting the same set (in any order)
+      // is a no-op and must not leave a spurious audit event.
+      if (tagIds !== null) {
+        const oldSet = new Set(oldTagIds);
+        const newSet = new Set(tagIds);
+        const tagSetChanged =
+          oldSet.size !== newSet.size ||
+          [...newSet].some((id) => !oldSet.has(id));
+        if (tagSetChanged) {
+          await emitEvent(tx, {
+            taskId: updateTaskParams.id,
+            userId,
+            type: TaskEventType.TAGS_CHANGED,
+            payload: { old: oldTagIds, new: tagIds },
+          });
+        }
+      }
+
+      return updated;
     });
     return createSuccessResponseWithData(updatedTask);
   }, "Failed to update task");

--- a/tests/unit/services/task.service.test.ts
+++ b/tests/unit/services/task.service.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TaskEventType } from "@prisma/client";
 import {
   createMockPrismaClient,
+  mockTx,
   type MockPrismaClient,
+  type MockTx,
 } from "@/tests/helpers/prisma-mock";
 import { buildTask, buildActiveTimer } from "@/tests/helpers/factories";
 
@@ -10,10 +13,11 @@ vi.mock("@/lib/prisma", () => {
   return { default: mock };
 });
 
-import { hasActiveDescendants } from "@/lib/services/task.service";
+import { hasActiveDescendants, updateTask } from "@/lib/services/task.service";
 import prisma from "@/lib/prisma";
 
 const db = prisma as unknown as MockPrismaClient;
+const tx = mockTx as MockTx;
 
 describe("hasActiveTimers", () => {
   beforeEach(() => {
@@ -102,6 +106,94 @@ describe("hasActiveTimers", () => {
     // Should NOT include task-4 (not a descendant of task-1)
     expect(db.activeTimer.findFirst).toHaveBeenCalledWith({
       where: { taskId: { in: ["task-1", "task-2", "task-3"] } },
+    });
+  });
+});
+
+describe("updateTask — TAGS_CHANGED event", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Route the mutation's transaction through the shared tx mock.
+    db.$transaction.mockImplementation((fn: (client: MockTx) => unknown) =>
+      fn(tx),
+    );
+    // Owner passes the access check (select is { project: { userId } }).
+    db.task.findUnique.mockResolvedValue({
+      project: { userId: "test-user-1" },
+    });
+    tx.task.update.mockResolvedValue(buildTask());
+    tx.taskEvent.create.mockResolvedValue({ id: "event-1" });
+  });
+
+  it("emits one TAGS_CHANGED with the before/after tag-id sets when tags change", async () => {
+    tx.taskTag.findMany.mockResolvedValue([{ tagId: 1 }, { tagId: 2 }]);
+
+    const result = await updateTask({
+      userId: "test-user-1",
+      updateTaskParams: {
+        id: "test-task-1",
+        title: "Test Task",
+        tagIds: [2, 3],
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(tx.taskEvent.create).toHaveBeenCalledTimes(1);
+    expect(tx.taskEvent.create).toHaveBeenCalledWith({
+      data: {
+        taskId: "test-task-1",
+        userId: "test-user-1",
+        eventType: TaskEventType.TAGS_CHANGED,
+        payload: { old: [1, 2], new: [2, 3] },
+      },
+    });
+  });
+
+  it("does not emit when the same tag set is re-submitted (order-independent)", async () => {
+    tx.taskTag.findMany.mockResolvedValue([{ tagId: 1 }, { tagId: 2 }]);
+
+    const result = await updateTask({
+      userId: "test-user-1",
+      updateTaskParams: {
+        id: "test-task-1",
+        title: "Test Task",
+        tagIds: [2, 1],
+      },
+    });
+
+    expect(result.success).toBe(true);
+    // The write still runs; only the spurious event is suppressed.
+    expect(tx.task.update).toHaveBeenCalledTimes(1);
+    expect(tx.taskEvent.create).not.toHaveBeenCalled();
+  });
+
+  it("does not read or emit tags when tagIds is null (tags untouched)", async () => {
+    const result = await updateTask({
+      userId: "test-user-1",
+      updateTaskParams: { id: "test-task-1", title: "Renamed", tagIds: null },
+    });
+
+    expect(result.success).toBe(true);
+    expect(tx.task.update).toHaveBeenCalledTimes(1);
+    expect(tx.taskTag.findMany).not.toHaveBeenCalled();
+    expect(tx.taskEvent.create).not.toHaveBeenCalled();
+  });
+
+  it("captures old as an empty set when first tagging an untagged task", async () => {
+    tx.taskTag.findMany.mockResolvedValue([]);
+
+    await updateTask({
+      userId: "test-user-1",
+      updateTaskParams: { id: "test-task-1", title: "Test Task", tagIds: [5] },
+    });
+
+    expect(tx.taskEvent.create).toHaveBeenCalledWith({
+      data: {
+        taskId: "test-task-1",
+        userId: "test-user-1",
+        eventType: TaskEventType.TAGS_CHANGED,
+        payload: { old: [], new: [5] },
+      },
     });
   });
 });


### PR DESCRIPTION
## What

Wire `updateTask` to emit a `TAGS_CHANGED` event into the `TaskEvent` audit ledger whenever a task's tag set changes via `tagIds`.

## Where

- `lib/services/task.service.ts` — `updateTask`: the mutation now runs inside `client.$transaction`, so the event insert rides the same transaction (a bad payload rolls the update back, per #23). Before the update it snapshots the prior per-user tag set (`tx.taskTag.findMany` scoped to `taskId` + actor `userId`); after, it emits `TAGS_CHANGED` via `emitEvent(tx, …)` only when the set actually changed.
- Payload: `{ old, new }` — before/after arrays of tag ids (`Int`), matching the committed Zod schema in `event.service.ts`.
- No changes to the shared `event.service.ts`.

## Behavior

- Editing tags to a different set emits exactly one `TAGS_CHANGED` capturing before/after.
- Re-submitting the same set (in any order) is a no-op — no spurious event. Comparison is set-based (order- and duplicate-independent).
- `tagIds: null` (tags untouched) reads nothing and emits nothing.
- Actor is the acting `userId` the service already holds.

## Tests

`tests/unit/services/task.service.test.ts` — new `updateTask — TAGS_CHANGED event` block (4 tests, TDD red→green): change emits with correct payload; no-op reorder emits nothing; `null` neither reads nor emits; first-tagging captures `old: []`. Assertions go through the real `emitEvent` to `tx.taskEvent.create`, so the Zod payload shape is exercised too.

Evidence: `pnpm test` → 8 files / 153 passed (149 baseline + 4). `tsc --noEmit` clean, `eslint` clean.

## Notes

- No deviation from the ticket. Payload matches the committed schema; the `event.service.ts` `TAGS_CHANGED` schema (`{ old: int[], new: int[] }`) needs no change.
- `updateTask` was not previously transactional; wrapped minimally (parent #23: emission rides the mutation's transaction). Estimate/title events are intentionally left to #51 — out of scope here.

Closes #53