### PR TITLE
feat: emit STARTED task event at first work

### DIFF
--- a/lib/services/activeTask.service.ts
+++ b/lib/services/activeTask.service.ts
@@ -6,6 +6,7 @@ import {
   serviceQuery,
   serviceQueryOrNotFound,
 } from "./serviceUtil";
+import { emitStartedOnce } from "./startedEvent";
 import { calculateDurationInSeconds } from "../util";
 
 export function getActiveTimer({ userId }: { userId: string }) {
@@ -81,6 +82,9 @@ export function startActiveTimer({
       const newActiveTimer = await tx.activeTimer.create({
         data: { userId, taskId, startedAt: now },
       });
+
+      // Record the task's first work; no-op if a STARTED already exists (#55).
+      await emitStartedOnce(tx, { taskId, userId, startedAt: now });
 
       return { activeTimer: newActiveTimer, timeEntry: createdTimeEntry };
     });

--- a/lib/services/startedEvent.ts
+++ b/lib/services/startedEvent.ts
@@ -1,0 +1,41 @@
+import { Prisma, TaskEventType } from "@prisma/client";
+import { emitEvent } from "./event.service";
+
+/**
+ * Emit a write-once STARTED event marking a task's first work (#23/#55).
+ *
+ * Skips the emit when the ledger already holds a STARTED for the task, so later
+ * timers or manual entries — even backdated ones — never move or duplicate it:
+ * corrections live in state, not in past events (#23).
+ *
+ * Runs on the caller's transaction client, so the guard read and the insert
+ * commit (or roll back) together with the caller's mutation. Note the guard is
+ * best-effort under concurrency: without a unique constraint on
+ * (taskId, eventType), two transactions racing on the same task could each see
+ * "no prior STARTED" and both insert. Acceptable single-user; a partial unique
+ * index would close it if that ever matters.
+ *
+ * Belongs conceptually in event.service.ts; kept separate while #51–#55 land in
+ * parallel so that shared file stays untouched.
+ */
+export async function emitStartedOnce(
+  tx: Prisma.TransactionClient,
+  {
+    taskId,
+    userId,
+    startedAt,
+  }: { taskId: string; userId: string; startedAt: Date },
+) {
+  const priorStarted = await tx.taskEvent.findFirst({
+    where: { taskId, eventType: TaskEventType.STARTED },
+    select: { id: true },
+  });
+  if (priorStarted) return null;
+
+  return emitEvent(tx, {
+    taskId,
+    userId,
+    type: TaskEventType.STARTED,
+    payload: { startedAt },
+  });
+}

--- a/lib/services/timeEntry.service.ts
+++ b/lib/services/timeEntry.service.ts
@@ -4,6 +4,7 @@ import {
   createSuccessResponseWithData,
   serviceAction,
 } from "./serviceUtil";
+import { emitStartedOnce } from "./startedEvent";
 import { calculateDurationInSeconds } from "../util";
 
 // ─── Reads ─────────────────────────────────────────────────────────────────────
@@ -61,14 +62,24 @@ export function createManualTimeEntry({
         "User does not have access to this task",
       );
 
-    const entry = await client.timeEntry.create({
-      data: {
-        task: { connect: { id: taskId } },
-        user: { connect: { id: userId } },
-        startedAt,
-        stoppedAt,
-        duration: calculateDurationInSeconds(startedAt, stoppedAt),
-      },
+    // Transaction so the entry and any first-work STARTED event commit together
+    // (emit failure rolls back the entry). This path was single-statement before #55.
+    const entry = await client.$transaction(async (tx) => {
+      const created = await tx.timeEntry.create({
+        data: {
+          task: { connect: { id: taskId } },
+          user: { connect: { id: userId } },
+          startedAt,
+          stoppedAt,
+          duration: calculateDurationInSeconds(startedAt, stoppedAt),
+        },
+      });
+
+      // Record the task's first work; no-op if a STARTED already exists —
+      // a backdated entry never moves or re-emits it (#55).
+      await emitStartedOnce(tx, { taskId, userId, startedAt });
+
+      return created;
     });
 
     return createSuccessResponseWithData(entry);

--- a/tests/unit/services/activeTask.service.test.ts
+++ b/tests/unit/services/activeTask.service.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TaskEventType } from "@prisma/client";
 import {
   createMockPrismaClient,
   mockTx,
@@ -208,6 +209,71 @@ describe("startActiveTimer", () => {
     const createTimerOrder = tx.activeTimer.create.mock.invocationCallOrder[0];
     expect(createEntryOrder).toBeLessThan(deleteTimerOrder);
     expect(deleteTimerOrder).toBeLessThan(createTimerOrder);
+  });
+});
+
+describe("startActiveTimer — STARTED event", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db.$transaction.mockImplementation((fn) => fn(tx));
+    db.task.findUnique.mockResolvedValue(
+      buildTask({ createdById: "test-user-1" }),
+    );
+    tx.activeTimer.findUnique.mockResolvedValue(null);
+    tx.activeTimer.create.mockResolvedValue(buildActiveTimer());
+  });
+
+  it("emits STARTED with the start time on the task's first work", async () => {
+    tx.taskEvent.findFirst.mockResolvedValue(null); // no prior STARTED
+
+    await startActiveTimer({ userId: "test-user-1", taskId: "test-task-1" });
+
+    expect(tx.taskEvent.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          taskId: "test-task-1",
+          userId: "test-user-1",
+          eventType: TaskEventType.STARTED,
+          // stored as an ISO-8601 string by emitEvent's timestamp transform
+          payload: { startedAt: expect.any(String) },
+        }),
+      }),
+    );
+  });
+
+  it("does not emit a second STARTED when the task already has one", async () => {
+    tx.taskEvent.findFirst.mockResolvedValue({ id: "existing-started" });
+
+    await startActiveTimer({ userId: "test-user-1", taskId: "test-task-1" });
+
+    expect(tx.taskEvent.create).not.toHaveBeenCalled();
+  });
+
+  it("scopes the prior-STARTED guard to this task and event type", async () => {
+    tx.taskEvent.findFirst.mockResolvedValue(null);
+
+    await startActiveTimer({ userId: "test-user-1", taskId: "test-task-1" });
+
+    expect(tx.taskEvent.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          taskId: "test-task-1",
+          eventType: TaskEventType.STARTED,
+        }),
+      }),
+    );
+  });
+
+  it("fails the action (rolls back) when the STARTED emit throws", async () => {
+    tx.taskEvent.findFirst.mockResolvedValue(null);
+    tx.taskEvent.create.mockRejectedValue(new Error("emit failed"));
+
+    const result = await startActiveTimer({
+      userId: "test-user-1",
+      taskId: "test-task-1",
+    });
+
+    expect(result.success).toBe(false);
   });
 });
 

--- a/tests/unit/services/timeEntry.service.test.ts
+++ b/tests/unit/services/timeEntry.service.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TaskEventType } from "@prisma/client";
 import {
   createMockPrismaClient,
+  mockTx,
   type MockPrismaClient,
+  type MockTx,
 } from "@/tests/helpers/prisma-mock";
 import { buildTask, buildTimeEntry } from "@/tests/helpers/factories";
 
@@ -19,6 +22,7 @@ import {
 import prisma from "@/lib/prisma";
 
 const db = prisma as unknown as MockPrismaClient;
+const tx = mockTx as MockTx;
 
 // ─── getTimeEntriesForTask ─────────────────────────────────────────────────────
 
@@ -179,8 +183,10 @@ describe("createManualTimeEntry", () => {
     db.task.findUnique.mockResolvedValue(
       buildTask({ createdById: "test-user-1" }),
     );
+    // Runs inside a $transaction since #55, so the create rides the tx client.
+    db.$transaction.mockImplementation((fn) => fn(tx));
     const created = buildTimeEntry({ duration: 3600 });
-    db.timeEntry.create.mockResolvedValue(created);
+    tx.timeEntry.create.mockResolvedValue(created);
 
     const result = await createManualTimeEntry({
       userId: "test-user-1",
@@ -193,7 +199,7 @@ describe("createManualTimeEntry", () => {
     if (result.success) {
       expect(result.data).toEqual(created);
     }
-    expect(db.timeEntry.create).toHaveBeenCalledWith({
+    expect(tx.timeEntry.create).toHaveBeenCalledWith({
       data: {
         task: { connect: { id: "test-task-1" } },
         user: { connect: { id: "test-user-1" } },
@@ -218,6 +224,90 @@ describe("createManualTimeEntry", () => {
       where: { id: "test-task-1", deletedAt: null },
       select: { createdById: true },
     });
+  });
+});
+
+// ─── createManualTimeEntry — STARTED event ───────────────────────────────────────
+
+describe("createManualTimeEntry — STARTED event", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db.$transaction.mockImplementation((fn) => fn(tx));
+    db.task.findUnique.mockResolvedValue(
+      buildTask({ createdById: "test-user-1" }),
+    );
+    tx.timeEntry.create.mockResolvedValue(buildTimeEntry());
+  });
+
+  it("emits STARTED with the entry's start time when the task has no prior STARTED", async () => {
+    tx.taskEvent.findFirst.mockResolvedValue(null);
+
+    await createManualTimeEntry({
+      userId: "test-user-1",
+      taskId: "test-task-1",
+      startedAt: new Date("2026-01-01T10:00:00Z"),
+      stoppedAt: new Date("2026-01-01T11:00:00Z"),
+    });
+
+    expect(tx.taskEvent.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          taskId: "test-task-1",
+          userId: "test-user-1",
+          eventType: TaskEventType.STARTED,
+          payload: { startedAt: "2026-01-01T10:00:00.000Z" },
+        }),
+      }),
+    );
+  });
+
+  it("does not re-emit STARTED for a backdated entry when one already exists", async () => {
+    // Task already started (via timer or an earlier entry); a later, backdated
+    // manual entry must not move or duplicate STARTED (#23: corrections live in state).
+    tx.taskEvent.findFirst.mockResolvedValue({ id: "existing-started" });
+
+    await createManualTimeEntry({
+      userId: "test-user-1",
+      taskId: "test-task-1",
+      startedAt: new Date("2025-12-01T08:00:00Z"), // backdated before the existing STARTED
+      stoppedAt: new Date("2025-12-01T09:00:00Z"),
+    });
+
+    expect(tx.taskEvent.create).not.toHaveBeenCalled();
+  });
+
+  it("scopes the prior-STARTED guard to this task and event type", async () => {
+    tx.taskEvent.findFirst.mockResolvedValue(null);
+
+    await createManualTimeEntry({
+      userId: "test-user-1",
+      taskId: "test-task-1",
+      startedAt: new Date("2026-01-01T10:00:00Z"),
+      stoppedAt: new Date("2026-01-01T11:00:00Z"),
+    });
+
+    expect(tx.taskEvent.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          taskId: "test-task-1",
+          eventType: TaskEventType.STARTED,
+        }),
+      }),
+    );
+  });
+
+  it("fails the action (rolls back) when the STARTED emit throws", async () => {
+    tx.taskEvent.findFirst.mockResolvedValue(null);
+    tx.taskEvent.create.mockRejectedValue(new Error("emit failed"));
+
+    const result = await createManualTimeEntry({
+      userId: "test-user-1",
+      taskId: "test-task-1",
+      startedAt: new Date("2026-01-01T10:00:00Z"),
+      stoppedAt: new Date("2026-01-01T11:00:00Z"),
+    });
+
+    expect(result.success).toBe(false);
   });
 });
 


### PR DESCRIPTION
## What

Wires the write-once `STARTED {startedAt}` event into both work-initiating paths, per #55.

## Where

- `lib/services/startedEvent.ts` (new) — `emitStartedOnce(tx, { taskId, userId, startedAt })`: guards on no prior `STARTED` for the task (queried on the caller's transaction client), then emits via `emitEvent`. Write-once: later timers or manual entries — even backdated — never move or re-emit it (#23 grill: corrections live in state, not in past events). Conceptual home is `event.service.ts`; kept in its own module so the shared file stays untouched while #51–#55 land in parallel — fold in later if wanted.
- `lib/services/activeTask.service.ts` — `startActiveTimer` calls the helper inside its existing transaction.
- `lib/services/timeEntry.service.ts` — `createManualTimeEntry` now wraps entry create + emit in one `$transaction` (path was single-statement before), so an emit failure rolls back the entry.

## Test evidence

8 new unit tests across both service test files:

- first timer start emits `STARTED` with the start time; second start does not re-emit
- first manual entry emits `STARTED` with the entry's `startedAt` (exact ISO asserted through the real Zod transform — `emitEvent` is not mocked); a later backdated entry does not re-emit
- guard query scoped to `{ taskId, eventType: STARTED }` on both paths
- emit failure fails the action (transaction rollback) on both paths

Full suite: 8 files / 157 tests green (`pnpm test`), was 149 on base. `tsc --noEmit` clean. No new lint errors (2 pre-existing `no-explicit-any` in untouched test code remain).

## Notes

- No schema changes, no migrations; `TaskEvent` from #50 as-is.
- Honest limit, flagged by review: the in-transaction guard makes emit + mutation atomic but does not fully serialize concurrent starts on the same task — without a unique constraint on `(taskId, eventType)`, two racing transactions could both pass the guard. Negligible single-user; a partial unique index would close it if it ever matters.

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)