### PR TITLE
feat: emit SUBTASK_CREATED / SUBTASK_REMOVED task events

### DIFF
--- a/lib/services/task.service.ts
+++ b/lib/services/task.service.ts
@@ -1,5 +1,7 @@
+import { TaskEventType } from "@prisma/client";
 import client from "@/lib/prisma";
 import { CreateTaskParams, UpdateTaskParams } from "../schema/task";
+import { emitEvent } from "./event.service";
 import {
   createServiceErrorResponse,
   createSuccessResponseWithData,
@@ -163,29 +165,44 @@ export function createTask({
       }
     }
 
-    const task = await client.task.create({
-      data: {
-        title: createTaskParams.title,
-        description: createTaskParams.description,
-        estimate: createTaskParams.estimate,
-        project: { connect: { id: createTaskParams.projectId } },
-        createdBy: { connect: { id: userId } },
-        ...(createTaskParams.parentId
-          ? { parent: { connect: { id: createTaskParams.parentId } } }
-          : {}),
-        todoItems: {
-          create: createTaskParams.todoItems?.map((todo) => ({
-            title: todo.title,
-            estimate: todo.estimate,
-          })),
+    const task = await client.$transaction(async (tx) => {
+      const created = await tx.task.create({
+        data: {
+          title: createTaskParams.title,
+          description: createTaskParams.description,
+          estimate: createTaskParams.estimate,
+          project: { connect: { id: createTaskParams.projectId } },
+          createdBy: { connect: { id: userId } },
+          ...(createTaskParams.parentId
+            ? { parent: { connect: { id: createTaskParams.parentId } } }
+            : {}),
+          todoItems: {
+            create: createTaskParams.todoItems?.map((todo) => ({
+              title: todo.title,
+              estimate: todo.estimate,
+            })),
+          },
+          taskTags: {
+            create: createTaskParams.tagIds?.map((tagId) => ({
+              tag: { connect: { id: tagId } },
+              user: { connect: { id: userId } },
+            })),
+          },
         },
-        taskTags: {
-          create: createTaskParams.tagIds?.map((tagId) => ({
-            tag: { connect: { id: tagId } },
-            user: { connect: { id: userId } },
-          })),
-        },
-      },
+      });
+
+      // Record the new subtask on its direct parent's event trail (#52).
+      // Emitted on the parent only; creation has no cascade to exclude.
+      if (createTaskParams.parentId) {
+        await emitEvent(tx, {
+          taskId: createTaskParams.parentId,
+          userId,
+          type: TaskEventType.SUBTASK_CREATED,
+          payload: { childTaskId: created.id, childTitle: created.title },
+        });
+      }
+
+      return created;
     });
     return createSuccessResponseWithData(task);
   }, "Failed to create task");
@@ -257,6 +274,7 @@ export function deleteTask({
       where: { id: taskId, deletedAt: null },
       select: {
         id: true,
+        title: true, // for the SUBTASK_REMOVED payload on the parent (#52)
         parentId: true,
         projectId: true,
         completedAt: true,
@@ -307,6 +325,18 @@ export function deleteTask({
 
       const plan = buildTransitionPlan("DELETE", task, ancestors, descendants);
       await executePlan(plan, tx);
+
+      // Record the removal on the former direct parent's trail (#52). Only the
+      // directly-deleted task notifies its parent; descendants swept up by the
+      // same cascade do not emit (ADR-0020 boundary).
+      if (task.parentId) {
+        await emitEvent(tx, {
+          taskId: task.parentId,
+          userId,
+          type: TaskEventType.SUBTASK_REMOVED,
+          payload: { childTaskId: task.id, childTitle: task.title },
+        });
+      }
 
       return createSuccessResponseWithData({
         id: taskId,

--- a/tests/helpers/prisma-mock.ts
+++ b/tests/helpers/prisma-mock.ts
@@ -7,6 +7,7 @@ function mockMethods() {
     findMany: vi.fn(),
     create: vi.fn(),
     update: vi.fn(),
+    updateMany: vi.fn(),
     delete: vi.fn(),
     deleteMany: vi.fn(),
     count: vi.fn(),

--- a/tests/unit/services/task.service.test.ts
+++ b/tests/unit/services/task.service.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TaskEventType } from "@prisma/client";
 import {
   createMockPrismaClient,
+  mockTx,
   type MockPrismaClient,
+  type MockTx,
 } from "@/tests/helpers/prisma-mock";
 import { buildTask, buildActiveTimer } from "@/tests/helpers/factories";
 
@@ -10,10 +13,38 @@ vi.mock("@/lib/prisma", () => {
   return { default: mock };
 });
 
-import { hasActiveDescendants } from "@/lib/services/task.service";
+import {
+  hasActiveDescendants,
+  createTask,
+  deleteTask,
+  completeTask,
+  archiveTask,
+} from "@/lib/services/task.service";
 import prisma from "@/lib/prisma";
 
 const db = prisma as unknown as MockPrismaClient;
+const tx = mockTx as MockTx;
+
+// Subtask events are asserted by filtering for the specific eventType, never by
+// "taskEvent.create was never called" — sibling tickets (#51 CREATED, #54
+// DELETED) add other events on these same paths, and these assertions must stay
+// green after those merges.
+const subtaskEventCalls = (type: TaskEventType) =>
+  tx.taskEvent.create.mock.calls.filter(
+    (call: unknown[]) =>
+      (call[0] as { data?: { eventType?: TaskEventType } } | undefined)?.data
+        ?.eventType === type,
+  );
+
+// Minimal LineageNode row as returned by the hierarchy fetches
+// (getAllAncestors / collectDescendantNodes selects).
+const lineageNode = (id: string, parentId: string | null) => ({
+  id,
+  parentId,
+  completedAt: null,
+  archivedAt: null,
+  deletedAt: null,
+});
 
 describe("hasActiveTimers", () => {
   beforeEach(() => {
@@ -103,5 +134,219 @@ describe("hasActiveTimers", () => {
     expect(db.activeTimer.findFirst).toHaveBeenCalledWith({
       where: { taskId: { in: ["task-1", "task-2", "task-3"] } },
     });
+  });
+});
+
+describe("createTask — SUBTASK_CREATED events", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db.$transaction.mockImplementation((fn: (tx: MockTx) => unknown) => fn(tx));
+    tx.taskEvent.create.mockResolvedValue({ id: "event-1" });
+  });
+
+  it("emits SUBTASK_CREATED on the direct parent when a subtask is created under it", async () => {
+    db.project.findUnique.mockResolvedValue({ userId: "test-user-1" });
+    db.task.findUnique.mockResolvedValue({ id: "parent-1" }); // parent existence check
+    tx.task.create.mockResolvedValue(
+      buildTask({ id: "child-1", title: "Child task", parentId: "parent-1" }),
+    );
+
+    const result = await createTask({
+      userId: "test-user-1",
+      createTaskParams: {
+        projectId: "test-project-1",
+        parentId: "parent-1",
+        title: "Child task",
+      },
+    });
+
+    expect(result.success).toBe(true);
+    // Exactly one SUBTASK_CREATED, targeting the direct parent — not the new
+    // task itself, not any ancestor above the parent.
+    const createdEvents = subtaskEventCalls(TaskEventType.SUBTASK_CREATED);
+    expect(createdEvents).toHaveLength(1);
+    expect(createdEvents[0][0]).toEqual({
+      data: {
+        taskId: "parent-1",
+        userId: "test-user-1",
+        eventType: TaskEventType.SUBTASK_CREATED,
+        payload: { childTaskId: "child-1", childTitle: "Child task" },
+      },
+    });
+  });
+
+  it("does not emit SUBTASK_CREATED when a top-level task is created without a parent", async () => {
+    db.project.findUnique.mockResolvedValue({ userId: "test-user-1" });
+    tx.task.create.mockResolvedValue(
+      buildTask({ id: "root-1", title: "Root task", parentId: null }),
+    );
+
+    const result = await createTask({
+      userId: "test-user-1",
+      createTaskParams: {
+        projectId: "test-project-1",
+        parentId: null,
+        title: "Root task",
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(subtaskEventCalls(TaskEventType.SUBTASK_CREATED)).toHaveLength(0);
+  });
+});
+
+describe("deleteTask — SUBTASK_REMOVED events", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db.$transaction.mockImplementation((fn: (tx: MockTx) => unknown) => fn(tx));
+    tx.activeTimer.findFirst.mockResolvedValue(null);
+    tx.task.updateMany.mockResolvedValue({ count: 1 });
+    tx.taskEvent.create.mockResolvedValue({ id: "event-1" });
+  });
+
+  it("emits SUBTASK_REMOVED on the former direct parent when a subtask is deleted", async () => {
+    db.task.findUnique.mockResolvedValue(
+      buildTask({
+        id: "child-1",
+        title: "Child task",
+        parentId: "parent-1",
+        project: { userId: "test-user-1" },
+      }),
+    );
+    // getAllAncestors → parent-1 is a root (no further parent)
+    tx.task.findUnique.mockResolvedValue(lineageNode("parent-1", null));
+    // collectDescendantNodes → child-1 is a leaf
+    tx.task.findMany.mockResolvedValue([lineageNode("child-1", "parent-1")]);
+
+    const result = await deleteTask({
+      taskId: "child-1",
+      userId: "test-user-1",
+    });
+
+    expect(result.success).toBe(true);
+    expect(tx.taskEvent.create).toHaveBeenCalledWith({
+      data: {
+        taskId: "parent-1",
+        userId: "test-user-1",
+        eventType: TaskEventType.SUBTASK_REMOVED,
+        payload: { childTaskId: "child-1", childTitle: "Child task" },
+      },
+    });
+  });
+
+  it("emits no SUBTASK_REMOVED when deleting a top-level subtree (cascade only)", async () => {
+    // Deleting a root task cascades to its descendants; none of those cascaded
+    // removals emit, and the root itself has no parent to notify.
+    db.task.findUnique.mockResolvedValue(
+      buildTask({
+        id: "parent-1",
+        title: "Parent",
+        parentId: null,
+        project: { userId: "test-user-1" },
+      }),
+    );
+    tx.task.findMany.mockResolvedValue([
+      lineageNode("parent-1", null),
+      lineageNode("child-1", "parent-1"),
+      lineageNode("grandchild-1", "child-1"),
+    ]);
+
+    const result = await deleteTask({
+      taskId: "parent-1",
+      userId: "test-user-1",
+    });
+
+    expect(result.success).toBe(true);
+    expect(subtaskEventCalls(TaskEventType.SUBTASK_REMOVED)).toHaveLength(0);
+  });
+
+  it("emits SUBTASK_REMOVED for the directly-deleted task only, never its cascaded children", async () => {
+    // Delete a mid-level task that has both a parent (top-1) and a child
+    // (grandchild-1). Only the direct removal (middle-1 from top-1) emits.
+    db.task.findUnique.mockResolvedValue(
+      buildTask({
+        id: "middle-1",
+        title: "Middle",
+        parentId: "top-1",
+        project: { userId: "test-user-1" },
+      }),
+    );
+    tx.task.findUnique.mockResolvedValue(lineageNode("top-1", null));
+    tx.task.findMany.mockResolvedValue([
+      lineageNode("middle-1", "top-1"),
+      lineageNode("grandchild-1", "middle-1"),
+    ]);
+
+    await deleteTask({ taskId: "middle-1", userId: "test-user-1" });
+
+    const removed = subtaskEventCalls(TaskEventType.SUBTASK_REMOVED);
+    expect(removed).toHaveLength(1);
+    expect(removed[0][0]).toEqual({
+      data: {
+        taskId: "top-1",
+        userId: "test-user-1",
+        eventType: TaskEventType.SUBTASK_REMOVED,
+        payload: { childTaskId: "middle-1", childTitle: "Middle" },
+      },
+    });
+    // Never for the cascaded grandchild.
+    expect(tx.taskEvent.create).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          eventType: TaskEventType.SUBTASK_REMOVED,
+          payload: expect.objectContaining({ childTaskId: "grandchild-1" }),
+        }),
+      }),
+    );
+  });
+});
+
+describe("completeTask / archiveTask — no subtask events on cascades", () => {
+  // AC #52: cascading operations (complete/archive on a subtree) never emit
+  // SUBTASK_CREATED/SUBTASK_REMOVED. Assertions filter for the two subtask
+  // types only, so they stay green once #54 wires COMPLETED/ARCHIVED events
+  // onto these same paths.
+  const subtree = [
+    lineageNode("parent-1", null),
+    lineageNode("child-1", "parent-1"),
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db.$transaction.mockImplementation((fn: (tx: MockTx) => unknown) => fn(tx));
+    tx.activeTimer.findFirst.mockResolvedValue(null);
+    tx.task.updateMany.mockResolvedValue({ count: 2 });
+    tx.taskEvent.create.mockResolvedValue({ id: "event-1" });
+    db.task.findUnique.mockResolvedValue(
+      buildTask({
+        id: "parent-1",
+        title: "Parent",
+        parentId: null,
+        project: { userId: "test-user-1" },
+      }),
+    );
+    tx.task.findMany.mockResolvedValue(subtree);
+  });
+
+  it("completing a subtree emits no SUBTASK_CREATED/SUBTASK_REMOVED", async () => {
+    const result = await completeTask({
+      taskId: "parent-1",
+      userId: "test-user-1",
+    });
+
+    expect(result.success).toBe(true);
+    expect(subtaskEventCalls(TaskEventType.SUBTASK_CREATED)).toHaveLength(0);
+    expect(subtaskEventCalls(TaskEventType.SUBTASK_REMOVED)).toHaveLength(0);
+  });
+
+  it("archiving a subtree emits no SUBTASK_CREATED/SUBTASK_REMOVED", async () => {
+    const result = await archiveTask({
+      taskId: "parent-1",
+      userId: "test-user-1",
+    });
+
+    expect(result.success).toBe(true);
+    expect(subtaskEventCalls(TaskEventType.SUBTASK_CREATED)).toHaveLength(0);
+    expect(subtaskEventCalls(TaskEventType.SUBTASK_REMOVED)).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## What

Wires the two structural subtask events (#52, part of #23) in `lib/services/task.service.ts`:

- **`createTask`**: emits `SUBTASK_CREATED {childTaskId, childTitle}` on the direct parent when a task is created with a `parentId`. The create is now wrapped in `client.$transaction` so the emit rides the mutation — emit failure rolls the task creation back (per #23 grill rule).
- **`deleteTask`**: emits `SUBTASK_REMOVED {childTaskId, childTitle}` on the (former) direct parent, inside the existing transaction. Direct target only — descendants removed by the same cascade never emit (ADR-0020 boundary). The task fetch now selects `title` for the payload.

Actor `userId` = the acting user the service already receives. `tests/helpers/prisma-mock.ts` gains `updateMany` (first test to exercise `executePlan` paths; #54 will need it too).

## Notes for reviewer

- Deleting a subtask is today's only "removed" path — `UpdateTaskParams` has no `parentId`, so no reparenting exists to wire. When reparenting lands, its service must emit `SUBTASK_REMOVED` (old parent) / `SUBTASK_CREATED` (new parent).
- `restoreDeletedTask` deliberately does not re-emit `SUBTASK_CREATED`: restore is not creation (#54 owns `RESTORED`). A parent's trail can therefore read "removed" without a matching re-add after a restore — flagging for the #23 analysis session.
- CONTEXT.md:96 ("zero `emitEvent` call sites") goes stale with any of the five wiring PRs; suggest one CONTEXT.md touch-up after all of #51–#55 merge instead of five conflicting edits.
- Test assertions filter by `eventType` (never "no event at all"), so they stay green when #51 (`CREATED`) and #54 (`DELETED`/`COMPLETED`/…) wire additional events onto these same code paths.

## Test evidence

- TDD red-green at the service seam; 7 new tests: parent-only `SUBTASK_CREATED` (exactly one, correct payload), no emit without parent, `SUBTASK_REMOVED` on former parent, no emit on root-subtree delete, direct-target-only emit on mid-level delete (grandchild cascade excluded), no subtask events from `completeTask`/`archiveTask` cascades.
- Full suite: **8 files / 156 tests green** (baseline 149 + 7).
- `tsc --noEmit` clean. No schema/migration changes; tests use the prisma mock.

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)