### PR TITLE
feat: emit CREATED + ESTIMATE_CHANGED task events

### DIFF
--- a/lib/services/task.service.ts
+++ b/lib/services/task.service.ts
@@ -1,5 +1,7 @@
+import { TaskEventType } from "@prisma/client";
 import client from "@/lib/prisma";
 import { CreateTaskParams, UpdateTaskParams } from "../schema/task";
+import { emitEvent } from "./event.service";
 import {
   createServiceErrorResponse,
   createSuccessResponseWithData,
@@ -163,29 +165,51 @@ export function createTask({
       }
     }
 
-    const task = await client.task.create({
-      data: {
-        title: createTaskParams.title,
-        description: createTaskParams.description,
-        estimate: createTaskParams.estimate,
-        project: { connect: { id: createTaskParams.projectId } },
-        createdBy: { connect: { id: userId } },
-        ...(createTaskParams.parentId
-          ? { parent: { connect: { id: createTaskParams.parentId } } }
-          : {}),
-        todoItems: {
-          create: createTaskParams.todoItems?.map((todo) => ({
-            title: todo.title,
-            estimate: todo.estimate,
-          })),
+    const task = await client.$transaction(async (tx) => {
+      const created = await tx.task.create({
+        data: {
+          title: createTaskParams.title,
+          description: createTaskParams.description,
+          estimate: createTaskParams.estimate,
+          project: { connect: { id: createTaskParams.projectId } },
+          createdBy: { connect: { id: userId } },
+          ...(createTaskParams.parentId
+            ? { parent: { connect: { id: createTaskParams.parentId } } }
+            : {}),
+          todoItems: {
+            create: createTaskParams.todoItems?.map((todo) => ({
+              title: todo.title,
+              estimate: todo.estimate,
+            })),
+          },
+          taskTags: {
+            create: createTaskParams.tagIds?.map((tagId) => ({
+              tag: { connect: { id: tagId } },
+              user: { connect: { id: userId } },
+            })),
+          },
         },
-        taskTags: {
-          create: createTaskParams.tagIds?.map((tagId) => ({
-            tag: { connect: { id: tagId } },
-            user: { connect: { id: userId } },
-          })),
+      });
+
+      // CREATED marks the task's birth: title always, estimate/parentId only
+      // when set. A task born with an estimate is fully covered here — no
+      // separate ESTIMATE_CHANGED fires at creation (#51).
+      await emitEvent(tx, {
+        taskId: created.id,
+        userId,
+        type: TaskEventType.CREATED,
+        payload: {
+          title: createTaskParams.title,
+          ...(createTaskParams.estimate !== undefined
+            ? { estimate: createTaskParams.estimate }
+            : {}),
+          ...(createTaskParams.parentId
+            ? { parentId: createTaskParams.parentId }
+            : {}),
         },
-      },
+      });
+
+      return created;
     });
     return createSuccessResponseWithData(task);
   }, "Failed to create task");
@@ -204,7 +228,7 @@ export function updateTask({
   return serviceAction(async () => {
     const task = await client.task.findUnique({
       where: { id: updateTaskParams.id, deletedAt: null, archivedAt: null },
-      select: { project: { select: { userId: true } } },
+      select: { estimate: true, project: { select: { userId: true } } },
     });
     if (!task) {
       return createServiceErrorResponse("NOT_FOUND", "Task not found");
@@ -222,24 +246,46 @@ export function updateTask({
       );
     }
 
-    const updatedTask = await client.task.update({
-      where: { id: updateTaskParams.id },
-      data: {
-        title: updateTaskParams.title,
-        description: updateTaskParams.description,
-        estimate: updateTaskParams.estimate,
-        ...(updateTaskParams.tagIds !== null
-          ? {
-              taskTags: {
-                deleteMany: { userId },
-                create: updateTaskParams.tagIds.map((tagId) => ({
-                  tag: { connect: { id: tagId } },
-                  user: { connect: { id: userId } },
-                })),
-              },
-            }
-          : {}),
-      },
+    const oldEstimate = task.estimate;
+
+    const updatedTask = await client.$transaction(async (tx) => {
+      const updated = await tx.task.update({
+        where: { id: updateTaskParams.id },
+        data: {
+          title: updateTaskParams.title,
+          description: updateTaskParams.description,
+          estimate: updateTaskParams.estimate,
+          ...(updateTaskParams.tagIds !== null
+            ? {
+                taskTags: {
+                  deleteMany: { userId },
+                  create: updateTaskParams.tagIds.map((tagId) => ({
+                    tag: { connect: { id: tagId } },
+                    user: { connect: { id: userId } },
+                  })),
+                },
+              }
+            : {}),
+        },
+      });
+
+      // ESTIMATE_CHANGED fires only on a real change. `undefined` means the
+      // caller left estimate untouched (Prisma skips it), and an equal value is
+      // a no-op — neither belongs in the audit trail. `old` is nullable since
+      // the task may have had no estimate.
+      if (
+        updateTaskParams.estimate !== undefined &&
+        updateTaskParams.estimate !== oldEstimate
+      ) {
+        await emitEvent(tx, {
+          taskId: updateTaskParams.id,
+          userId,
+          type: TaskEventType.ESTIMATE_CHANGED,
+          payload: { old: oldEstimate, new: updateTaskParams.estimate },
+        });
+      }
+
+      return updated;
     });
     return createSuccessResponseWithData(updatedTask);
   }, "Failed to update task");

--- a/tests/unit/services/task.service.test.ts
+++ b/tests/unit/services/task.service.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TaskEventType } from "@prisma/client";
 import {
   createMockPrismaClient,
+  mockTx,
   type MockPrismaClient,
+  type MockTx,
 } from "@/tests/helpers/prisma-mock";
 import { buildTask, buildActiveTimer } from "@/tests/helpers/factories";
 
@@ -10,10 +13,15 @@ vi.mock("@/lib/prisma", () => {
   return { default: mock };
 });
 
-import { hasActiveDescendants } from "@/lib/services/task.service";
+import {
+  hasActiveDescendants,
+  createTask,
+  updateTask,
+} from "@/lib/services/task.service";
 import prisma from "@/lib/prisma";
 
 const db = prisma as unknown as MockPrismaClient;
+const tx = mockTx as MockTx;
 
 describe("hasActiveTimers", () => {
   beforeEach(() => {
@@ -103,5 +111,203 @@ describe("hasActiveTimers", () => {
     expect(db.activeTimer.findFirst).toHaveBeenCalledWith({
       where: { taskId: { in: ["task-1", "task-2", "task-3"] } },
     });
+  });
+});
+
+describe("createTask", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db.$transaction.mockImplementation((fn: (client: MockTx) => unknown) =>
+      fn(tx),
+    );
+    db.project.findUnique.mockResolvedValue({ userId: "test-user-1" });
+    tx.taskEvent.create.mockResolvedValue({ id: "event-1" });
+  });
+
+  it("emits one CREATED event carrying title, estimate, and parentId, in the transaction", async () => {
+    // Parent-existence check inside createTask
+    db.task.findUnique.mockResolvedValue({ id: "parent-1" });
+    tx.task.create.mockResolvedValue(
+      buildTask({ id: "task-1", parentId: "parent-1", estimate: 60 }),
+    );
+
+    const result = await createTask({
+      userId: "test-user-1",
+      createTaskParams: {
+        projectId: "project-1",
+        parentId: "parent-1",
+        title: "Write the docs",
+        estimate: 60,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(tx.taskEvent.create).toHaveBeenCalledTimes(1);
+    expect(tx.taskEvent.create).toHaveBeenCalledWith({
+      data: {
+        taskId: "task-1",
+        userId: "test-user-1",
+        eventType: TaskEventType.CREATED,
+        payload: {
+          title: "Write the docs",
+          estimate: 60,
+          parentId: "parent-1",
+        },
+      },
+    });
+  });
+
+  it("emits CREATED with only a title when the task has no estimate and no parent", async () => {
+    tx.task.create.mockResolvedValue(
+      buildTask({ id: "task-2", parentId: null, estimate: null }),
+    );
+
+    const result = await createTask({
+      userId: "test-user-1",
+      createTaskParams: {
+        projectId: "project-1",
+        parentId: null,
+        title: "Solo task",
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(tx.taskEvent.create).toHaveBeenCalledWith({
+      data: {
+        taskId: "task-2",
+        userId: "test-user-1",
+        eventType: TaskEventType.CREATED,
+        payload: { title: "Solo task" },
+      },
+    });
+  });
+
+  it("does not emit ESTIMATE_CHANGED at creation, even when born with an estimate", async () => {
+    tx.task.create.mockResolvedValue(
+      buildTask({ id: "task-3", parentId: null, estimate: 90 }),
+    );
+
+    await createTask({
+      userId: "test-user-1",
+      createTaskParams: {
+        projectId: "project-1",
+        parentId: null,
+        title: "Estimated at birth",
+        estimate: 90,
+      },
+    });
+
+    // Exactly one event, and it is CREATED — so no ESTIMATE_CHANGED rode along.
+    expect(tx.taskEvent.create).toHaveBeenCalledTimes(1);
+    expect(tx.taskEvent.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ eventType: TaskEventType.CREATED }),
+      }),
+    );
+  });
+});
+
+describe("updateTask", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db.$transaction.mockImplementation((fn: (client: MockTx) => unknown) =>
+      fn(tx),
+    );
+    tx.taskEvent.create.mockResolvedValue({ id: "event-1" });
+  });
+
+  it("emits ESTIMATE_CHANGED with old and new when the estimate changes", async () => {
+    db.task.findUnique.mockResolvedValue({
+      estimate: 60,
+      project: { userId: "test-user-1" },
+    });
+    tx.task.update.mockResolvedValue(buildTask({ id: "task-1", estimate: 120 }));
+
+    const result = await updateTask({
+      userId: "test-user-1",
+      updateTaskParams: {
+        id: "task-1",
+        title: "Updated title",
+        estimate: 120,
+        tagIds: null,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(tx.taskEvent.create).toHaveBeenCalledTimes(1);
+    expect(tx.taskEvent.create).toHaveBeenCalledWith({
+      data: {
+        taskId: "task-1",
+        userId: "test-user-1",
+        eventType: TaskEventType.ESTIMATE_CHANGED,
+        payload: { old: 60, new: 120 },
+      },
+    });
+  });
+
+  it("emits ESTIMATE_CHANGED with old null when setting an estimate on a task that had none", async () => {
+    db.task.findUnique.mockResolvedValue({
+      estimate: null,
+      project: { userId: "test-user-1" },
+    });
+    tx.task.update.mockResolvedValue(buildTask({ id: "task-1", estimate: 45 }));
+
+    await updateTask({
+      userId: "test-user-1",
+      updateTaskParams: {
+        id: "task-1",
+        title: "Now estimated",
+        estimate: 45,
+        tagIds: null,
+      },
+    });
+
+    expect(tx.taskEvent.create).toHaveBeenCalledWith({
+      data: {
+        taskId: "task-1",
+        userId: "test-user-1",
+        eventType: TaskEventType.ESTIMATE_CHANGED,
+        payload: { old: null, new: 45 },
+      },
+    });
+  });
+
+  it("does not emit ESTIMATE_CHANGED when the estimate is not part of the update", async () => {
+    db.task.findUnique.mockResolvedValue({
+      estimate: 60,
+      project: { userId: "test-user-1" },
+    });
+    tx.task.update.mockResolvedValue(buildTask({ id: "task-1", estimate: 60 }));
+
+    await updateTask({
+      userId: "test-user-1",
+      updateTaskParams: {
+        id: "task-1",
+        title: "Only the title changed",
+        tagIds: null,
+      },
+    });
+
+    expect(tx.taskEvent.create).not.toHaveBeenCalled();
+  });
+
+  it("does not emit ESTIMATE_CHANGED when the estimate is unchanged", async () => {
+    db.task.findUnique.mockResolvedValue({
+      estimate: 60,
+      project: { userId: "test-user-1" },
+    });
+    tx.task.update.mockResolvedValue(buildTask({ id: "task-1", estimate: 60 }));
+
+    await updateTask({
+      userId: "test-user-1",
+      updateTaskParams: {
+        id: "task-1",
+        title: "Re-saved with same estimate",
+        estimate: 60,
+        tagIds: null,
+      },
+    });
+
+    expect(tx.taskEvent.create).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What

Wire the first two `TaskEvent` emissions into `task.service.ts`, per #51 (parent #23, Iteration 2 — Event Log).

- **`createTask`** — now runs its write + emit inside one `client.$transaction` and appends a `CREATED` event with payload `{title, estimate?, parentId?}` (estimate/parentId included only when set). A task born with an estimate is covered by `CREATED` alone — no `ESTIMATE_CHANGED` at creation.
- **`updateTask`** — wraps its update in a `client.$transaction` and emits `ESTIMATE_CHANGED {old, new}` **only on a real change**. `estimate === undefined` means the caller left it untouched (Prisma skips the field) → no event; an equal value is a no-op → no event. `old` is nullable, so the set-from-nothing case records `{old: null, new: N}`. `oldEstimate` is snapshotted from the existing auth `findUnique` (widened its `select` with `estimate: true`) before the write.

Uses the authoritative `emitEvent(tx, { taskId, userId, type, payload })` primitive from #50; `event.service.ts` untouched.

## Where

- `lib/services/task.service.ts` — `createTask`, `updateTask`
- `tests/unit/services/task.service.test.ts` — new `createTask` / `updateTask` describe blocks

## Test evidence

- `pnpm test`: **8 files / 156 tests green** (149 baseline + 7 new).
- New tests: CREATED full payload / title-only / no-double-emit-at-creation; ESTIMATE_CHANGED on change and on set-from-null; no emit when estimate is absent or unchanged.
- `pnpm exec tsc --noEmit` clean; `eslint` clean on both files.

## Deviation from spec

Acceptance names estimate **"clear"**. That case is carried by the payload/`emitEvent` schema (`new: null`) but is **not reachable through `updateTask`**, because `UpdateTaskSchema.estimate` is `z.number().int().min(0).optional()` (`number | undefined`), not nullable — the input cannot express a clear. Set and change are fully wired. Widening the input schema is out of scope for this event-wiring ticket (it changes the update contract / form path); flagging for a follow-up if clearing an estimate becomes a real user flow.

## ⚠️ Coordinator merge note (parallel work with #53)

This branch is based on `6f33517` (pre-#53). Since then, **#53 (TAGS_CHANGED, PR #65) merged into `main-vibe`** and also rewrote `updateTask` + added to the same test file. GitHub will therefore show conflicts — they are **expected**, not a regression here (this branch never touched tags). Resolve by **combining**, not choosing a side:

- **`task.service.ts` imports** — both branches add the same `import { TaskEventType } from "@prisma/client"` and `import { emitEvent } from "./event.service"`. Dedupe.
- **`updateTask`** — both wrapped the update in one `client.$transaction` with a guarded emit after it. Keep #53's in-tx `oldTagIds` snapshot **and** this PR's widened `select: { estimate: true, project: {...} }` + `oldEstimate`; inside the transaction after `tx.task.update`, emit **both** `TAGS_CHANGED` (from #53) and `ESTIMATE_CHANGED` (from here), each behind its own change-guard.
- **`createTask`** — only this PR touches it; applies cleanly.
- **test file** — union the imports (`hasActiveDescendants, createTask, updateTask`) and both describe blocks; conventions already match (typed `mockImplementation`, `mockTx`, factories).

Closes #51
