### PR TITLE
feat: emit hierarchy transition task events w/ cascade causedBy

### DIFF
--- a/lib/services/task.service.ts
+++ b/lib/services/task.service.ts
@@ -1,5 +1,7 @@
+import { Prisma, TaskEventType } from "@prisma/client";
 import client from "@/lib/prisma";
 import { CreateTaskParams, UpdateTaskParams } from "../schema/task";
+import { emitEvent, type EmitEventInput } from "./event.service";
 import {
   createServiceErrorResponse,
   createSuccessResponseWithData,
@@ -91,6 +93,61 @@ async function executePlan(plan: TransitionPlan, tx: DbClient): Promise<void> {
       where: { id: { in: plan.setDeletedAt.ids } },
       data: { deletedAt: plan.setDeletedAt.value },
     });
+  }
+}
+
+/**
+ * The six hierarchy-transition verbs. All share `statusTransitionPayload`
+ * (`{at, causedBy?}`) in event.service, so a single payload shape is valid for
+ * whichever verb this helper is handed.
+ */
+type TransitionEventType =
+  | typeof TaskEventType.COMPLETED
+  | typeof TaskEventType.UNCOMPLETED
+  | typeof TaskEventType.ARCHIVED
+  | typeof TaskEventType.UNARCHIVED
+  | typeof TaskEventType.DELETED
+  | typeof TaskEventType.RESTORED;
+
+/**
+ * Emit one TaskEvent per task changed by a hierarchy transition (ADR-0020).
+ *
+ * `changed` is the transition plan's slot for the flag this verb touches. Its
+ * `ids` are already pruned, so descendants halted by the #44 stop rule — and any
+ * task the transition left unchanged — are absent and emit nothing. Its `value`
+ * is the stamped date, or null when the verb clears the flag (upward repairs) —
+ * then the event time is the act's time, now. The direct target (`targetTaskId`)
+ * gets `{at}`; every other changed task (a cascaded descendant, or an ancestor
+ * repaired by an upward transition) gets `{at, causedBy: targetTaskId}` under
+ * the SAME event `type`. Runs on the caller's `tx`, so a failure here rolls the
+ * whole transition back.
+ */
+async function emitTransitionEvents(
+  tx: Prisma.TransactionClient,
+  {
+    type,
+    userId,
+    targetTaskId,
+    changed,
+  }: {
+    type: TransitionEventType;
+    userId: string;
+    targetTaskId: string;
+    changed: { ids: string[]; value: Date | null };
+  },
+): Promise<void> {
+  const at = changed.value ?? new Date();
+  for (const id of changed.ids) {
+    // Every `TransitionEventType` maps to the same `statusTransitionPayload`, so
+    // this input satisfies whichever of the six arms `type` selects — TS checks
+    // that by distributing the literal over the extracted union, no cast needed.
+    const input: Extract<EmitEventInput, { type: TransitionEventType }> = {
+      taskId: id,
+      userId,
+      type,
+      payload: id === targetTaskId ? { at } : { at, causedBy: targetTaskId },
+    };
+    await emitEvent(tx, input);
   }
 }
 
@@ -307,6 +364,12 @@ export function deleteTask({
 
       const plan = buildTransitionPlan("DELETE", task, ancestors, descendants);
       await executePlan(plan, tx);
+      await emitTransitionEvents(tx, {
+        type: TaskEventType.DELETED,
+        userId,
+        targetTaskId: task.id,
+        changed: plan.setDeletedAt,
+      });
 
       return createSuccessResponseWithData({
         id: taskId,
@@ -397,6 +460,12 @@ export function completeTask({
         descendants,
       );
       await executePlan(plan, tx);
+      await emitTransitionEvents(tx, {
+        type: TaskEventType.COMPLETED,
+        userId,
+        targetTaskId: task.id,
+        changed: plan.setCompletedAt,
+      });
 
       return createSuccessResponseWithData({
         id: taskId,
@@ -451,6 +520,12 @@ export function uncompleteTask({
 
       const plan = buildTransitionPlan("UNCOMPLETE", task, ancestors);
       await executePlan(plan, tx);
+      await emitTransitionEvents(tx, {
+        type: TaskEventType.UNCOMPLETED,
+        userId,
+        targetTaskId: task.id,
+        changed: plan.setCompletedAt,
+      });
 
       return createSuccessResponseWithData({
         id: taskId,
@@ -526,6 +601,12 @@ export function archiveTask({
         descendants,
       );
       await executePlan(plan, tx);
+      await emitTransitionEvents(tx, {
+        type: TaskEventType.ARCHIVED,
+        userId,
+        targetTaskId: task.id,
+        changed: plan.setArchivedAt,
+      });
 
       return createSuccessResponseWithData({
         id: taskId,
@@ -577,6 +658,12 @@ export function unarchiveTask({
 
       const plan = buildTransitionPlan("UNARCHIVE", task, ancestors);
       await executePlan(plan, tx);
+      await emitTransitionEvents(tx, {
+        type: TaskEventType.UNARCHIVED,
+        userId,
+        targetTaskId: task.id,
+        changed: plan.setArchivedAt,
+      });
 
       return createSuccessResponseWithData({ id: taskId });
     });
@@ -625,6 +712,12 @@ export function restoreDeletedTask({
 
       const plan = buildTransitionPlan("UNDELETE", task, ancestors);
       await executePlan(plan, tx);
+      await emitTransitionEvents(tx, {
+        type: TaskEventType.RESTORED,
+        userId,
+        targetTaskId: task.id,
+        changed: plan.setDeletedAt,
+      });
 
       return createSuccessResponseWithData({
         id: taskId,

--- a/tests/helpers/prisma-mock.ts
+++ b/tests/helpers/prisma-mock.ts
@@ -7,6 +7,7 @@ function mockMethods() {
     findMany: vi.fn(),
     create: vi.fn(),
     update: vi.fn(),
+    updateMany: vi.fn(),
     delete: vi.fn(),
     deleteMany: vi.fn(),
     count: vi.fn(),

--- a/tests/unit/services/task.service.transitionEvents.test.ts
+++ b/tests/unit/services/task.service.transitionEvents.test.ts
@@ -1,0 +1,433 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  createMockPrismaClient,
+  mockTx,
+  type MockPrismaClient,
+} from "@/tests/helpers/prisma-mock";
+import { buildTask } from "@/tests/helpers/factories";
+
+vi.mock("@/lib/prisma", () => {
+  const mock = createMockPrismaClient();
+  return { default: mock };
+});
+
+import {
+  completeTask,
+  archiveTask,
+  deleteTask,
+  uncompleteTask,
+  unarchiveTask,
+  restoreDeletedTask,
+} from "@/lib/services/task.service";
+import prisma from "@/lib/prisma";
+
+const db = prisma as unknown as MockPrismaClient;
+
+const USER = "test-user-1";
+const PROJECT = "test-project-1";
+
+type Row = {
+  id: string;
+  parentId: string | null;
+  completedAt: Date | null;
+  archivedAt: Date | null;
+  deletedAt: Date | null;
+};
+
+function row(
+  id: string,
+  parentId: string | null,
+  overrides: Partial<Row> = {},
+): Row {
+  return {
+    id,
+    parentId,
+    completedAt: null,
+    archivedAt: null,
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+/** The target task as returned by the outer `client.task.findUnique`. */
+function target(overrides: Partial<Row> = {}) {
+  return buildTask({
+    id: "root",
+    parentId: null,
+    projectId: PROJECT,
+    project: { userId: USER },
+    ...overrides,
+  });
+}
+
+/** Rows the in-transaction descendant scan (`tx.task.findMany`) returns. */
+function tree(rows: Row[]) {
+  mockTx.task.findMany.mockResolvedValue(rows);
+  mockTx.activeTimer.findFirst.mockResolvedValue(null);
+}
+
+/**
+ * Rows the in-transaction ancestor walk (`tx.task.findUnique`, one call per
+ * parent) returns, keyed by id. Used by the upward-repair transitions.
+ */
+function ancestors(rows: Row[]) {
+  const map = new Map(rows.map((r) => [r.id, r]));
+  mockTx.task.findUnique.mockImplementation((args: { where: { id: string } }) =>
+    Promise.resolve(map.get(args.where.id) ?? null),
+  );
+}
+
+/** TaskEvent rows written during the call, in emission order. */
+function emitted() {
+  return mockTx.taskEvent.create.mock.calls.map(
+    (c) => (c[0] as { data: Record<string, unknown> }).data,
+  );
+}
+
+beforeEach(() => {
+  // clearAllMocks resets call history but NOT implementations, so re-establish
+  // happy-path defaults here — otherwise a test that makes an insert reject (see
+  // the rollback case) or configures ancestors would leak into later tests.
+  vi.clearAllMocks();
+  mockTx.taskEvent.create.mockResolvedValue({});
+  mockTx.task.findUnique.mockResolvedValue(null); // no ancestors unless a test sets them
+});
+
+describe("completeTask — event emission", () => {
+  it("emits COMPLETED on a leaf target with no causedBy", async () => {
+    db.task.findUnique.mockResolvedValue(target());
+    tree([row("root", null)]);
+
+    const result = await completeTask({ taskId: "root", userId: USER });
+
+    expect(result.success).toBe(true);
+    const events = emitted();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      taskId: "root",
+      userId: USER,
+      eventType: "COMPLETED",
+      payload: { at: expect.any(String) },
+    });
+    expect(events[0].payload).not.toHaveProperty("causedBy");
+  });
+
+  it("cascades COMPLETED to every descendant with causedBy = the direct target", async () => {
+    // root -> a -> b, none completed
+    db.task.findUnique.mockResolvedValue(target());
+    tree([row("root", null), row("a", "root"), row("b", "a")]);
+
+    const result = await completeTask({ taskId: "root", userId: USER });
+
+    expect(result.success).toBe(true);
+    const events = emitted();
+    expect(events).toHaveLength(3);
+
+    const byTask = Object.fromEntries(events.map((e) => [e.taskId, e]));
+    expect(byTask.root).toMatchObject({ eventType: "COMPLETED" });
+    expect(byTask.root.payload).not.toHaveProperty("causedBy");
+    // Even the deep descendant points at the direct target, not its parent.
+    expect(byTask.a.payload).toMatchObject({ causedBy: "root" });
+    expect(byTask.b.payload).toMatchObject({ causedBy: "root" });
+    // Same verb type for direct act and cascade.
+    expect(events.every((e) => e.eventType === "COMPLETED")).toBe(true);
+    // One shared timestamp for the single authorized act.
+    const ats = new Set(events.map((e) => (e.payload as { at: string }).at));
+    expect(ats.size).toBe(1);
+  });
+
+  it("emits nothing for a subtree pruned by the #44 stop rule", async () => {
+    // root -> a(completed) -> b : a is already completed, so a and b are pruned.
+    db.task.findUnique.mockResolvedValue(target());
+    tree([
+      row("root", null),
+      row("a", "root", { completedAt: new Date("2026-01-02") }),
+      row("b", "a"),
+    ]);
+
+    const result = await completeTask({ taskId: "root", userId: USER });
+
+    expect(result.success).toBe(true);
+    const events = emitted();
+    expect(events.map((e) => e.taskId)).toEqual(["root"]);
+  });
+
+  it("mixed branching tree: fresh branch cascades while the in-state sibling branch stays silent", async () => {
+    // root ─┬─ a ─ b          (fresh → cascade, causedBy = root)
+    //       └─ c* ─ d*        (already completed → pruned, no events)
+    const done = new Date("2026-01-02");
+    db.task.findUnique.mockResolvedValue(target());
+    tree([
+      row("root", null),
+      row("a", "root"),
+      row("b", "a"),
+      row("c", "root", { completedAt: done }),
+      row("d", "c", { completedAt: done }),
+    ]);
+
+    const result = await completeTask({ taskId: "root", userId: USER });
+
+    expect(result.success).toBe(true);
+    const events = emitted();
+    expect(events.map((e) => e.taskId).sort()).toEqual(["a", "b", "root"]);
+    expect(events.every((e) => e.eventType === "COMPLETED")).toBe(true);
+
+    const byTask = Object.fromEntries(events.map((e) => [e.taskId, e]));
+    expect(byTask.root.payload).not.toHaveProperty("causedBy");
+    expect(byTask.a.payload).toMatchObject({ causedBy: "root" });
+    expect(byTask.b.payload).toMatchObject({ causedBy: "root" });
+  });
+});
+
+describe("archiveTask — event emission", () => {
+  it("emits ARCHIVED on a leaf target with no causedBy", async () => {
+    db.task.findUnique.mockResolvedValue(target());
+    tree([row("root", null)]);
+
+    const result = await archiveTask({ taskId: "root", userId: USER });
+
+    expect(result.success).toBe(true);
+    const events = emitted();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      taskId: "root",
+      userId: USER,
+      eventType: "ARCHIVED",
+      payload: { at: expect.any(String) },
+    });
+    expect(events[0].payload).not.toHaveProperty("causedBy");
+  });
+
+  it("cascades ARCHIVED to descendants; direct target has no causedBy", async () => {
+    // root -> a -> b, none archived
+    db.task.findUnique.mockResolvedValue(target());
+    tree([row("root", null), row("a", "root"), row("b", "a")]);
+
+    const result = await archiveTask({ taskId: "root", userId: USER });
+
+    expect(result.success).toBe(true);
+    const events = emitted();
+    expect(events).toHaveLength(3);
+    expect(events.every((e) => e.eventType === "ARCHIVED")).toBe(true);
+
+    const byTask = Object.fromEntries(events.map((e) => [e.taskId, e]));
+    expect(byTask.root.payload).not.toHaveProperty("causedBy");
+    expect(byTask.a.payload).toMatchObject({ causedBy: "root" });
+    expect(byTask.b.payload).toMatchObject({ causedBy: "root" });
+  });
+
+  it("emits nothing for a subtree pruned by the stop rule", async () => {
+    // root -> a(archived) -> b : a already archived, so a and b are pruned.
+    db.task.findUnique.mockResolvedValue(target());
+    tree([
+      row("root", null),
+      row("a", "root", { archivedAt: new Date("2026-01-02") }),
+      row("b", "a"),
+    ]);
+
+    const result = await archiveTask({ taskId: "root", userId: USER });
+
+    expect(result.success).toBe(true);
+    expect(emitted().map((e) => e.taskId)).toEqual(["root"]);
+  });
+});
+
+describe("deleteTask — event emission", () => {
+  it("emits DELETED on a leaf target with no causedBy", async () => {
+    db.task.findUnique.mockResolvedValue(target());
+    tree([row("root", null)]);
+
+    const result = await deleteTask({ taskId: "root", userId: USER });
+
+    expect(result.success).toBe(true);
+    const events = emitted();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      taskId: "root",
+      userId: USER,
+      eventType: "DELETED",
+      payload: { at: expect.any(String) },
+    });
+    expect(events[0].payload).not.toHaveProperty("causedBy");
+  });
+
+  it("cascades DELETED to descendants; direct target has no causedBy", async () => {
+    // root -> a -> b, none deleted
+    db.task.findUnique.mockResolvedValue(target());
+    tree([row("root", null), row("a", "root"), row("b", "a")]);
+
+    const result = await deleteTask({ taskId: "root", userId: USER });
+
+    expect(result.success).toBe(true);
+    const events = emitted();
+    expect(events).toHaveLength(3);
+    expect(events.every((e) => e.eventType === "DELETED")).toBe(true);
+
+    const byTask = Object.fromEntries(events.map((e) => [e.taskId, e]));
+    expect(byTask.root.payload).not.toHaveProperty("causedBy");
+    expect(byTask.a.payload).toMatchObject({ causedBy: "root" });
+    expect(byTask.b.payload).toMatchObject({ causedBy: "root" });
+  });
+
+  it("emits nothing for a subtree pruned by the stop rule", async () => {
+    // root -> a(deleted) -> b : a already deleted, so a and b are pruned.
+    db.task.findUnique.mockResolvedValue(target());
+    tree([
+      row("root", null),
+      row("a", "root", { deletedAt: new Date("2026-01-02") }),
+      row("b", "a"),
+    ]);
+
+    const result = await deleteTask({ taskId: "root", userId: USER });
+
+    expect(result.success).toBe(true);
+    expect(emitted().map((e) => e.taskId)).toEqual(["root"]);
+  });
+});
+
+describe("uncompleteTask — event emission (upward repair)", () => {
+  it("emits UNCOMPLETED on the target and each repaired ancestor (causedBy = target)", async () => {
+    // root(completed) -> a(completed) -> leaf(completed); uncomplete the leaf.
+    const done = new Date("2026-01-02");
+    db.task.findUnique.mockResolvedValue(
+      target({ id: "leaf", parentId: "a", completedAt: done }),
+    );
+    ancestors([
+      row("a", "root", { completedAt: done }),
+      row("root", null, { completedAt: done }),
+    ]);
+
+    const result = await uncompleteTask({ taskId: "leaf", userId: USER });
+
+    expect(result.success).toBe(true);
+    const events = emitted();
+    expect(events.map((e) => e.taskId).sort()).toEqual(["a", "leaf", "root"]);
+    expect(events.every((e) => e.eventType === "UNCOMPLETED")).toBe(true);
+
+    const byTask = Object.fromEntries(events.map((e) => [e.taskId, e]));
+    expect(byTask.leaf.payload).not.toHaveProperty("causedBy");
+    expect(byTask.a.payload).toMatchObject({ causedBy: "leaf" });
+    expect(byTask.root.payload).toMatchObject({ causedBy: "leaf" });
+  });
+
+  it("stops the upward repair at the first uncompleted ancestor", async () => {
+    // root(uncompleted) -> a(completed) -> leaf(completed); repair stops below root.
+    const done = new Date("2026-01-02");
+    db.task.findUnique.mockResolvedValue(
+      target({ id: "leaf", parentId: "a", completedAt: done }),
+    );
+    ancestors([
+      row("a", "root", { completedAt: done }),
+      row("root", null), // not completed → not repaired, no event
+    ]);
+
+    const result = await uncompleteTask({ taskId: "leaf", userId: USER });
+
+    expect(result.success).toBe(true);
+    expect(emitted().map((e) => e.taskId).sort()).toEqual(["a", "leaf"]);
+  });
+});
+
+describe("unarchiveTask — event emission (upward repair)", () => {
+  it("emits UNARCHIVED on the target and each repaired ancestor (causedBy = target)", async () => {
+    // root(archived) -> a(archived) -> leaf(archived); unarchive the leaf.
+    const at = new Date("2026-01-02");
+    db.task.findUnique.mockResolvedValue(
+      target({ id: "leaf", parentId: "a", archivedAt: at }),
+    );
+    ancestors([
+      row("a", "root", { archivedAt: at }),
+      row("root", null, { archivedAt: at }),
+    ]);
+
+    const result = await unarchiveTask({ taskId: "leaf", userId: USER });
+
+    expect(result.success).toBe(true);
+    const events = emitted();
+    expect(events.map((e) => e.taskId).sort()).toEqual(["a", "leaf", "root"]);
+    expect(events.every((e) => e.eventType === "UNARCHIVED")).toBe(true);
+
+    const byTask = Object.fromEntries(events.map((e) => [e.taskId, e]));
+    expect(byTask.leaf.payload).not.toHaveProperty("causedBy");
+    expect(byTask.a.payload).toMatchObject({ causedBy: "leaf" });
+    expect(byTask.root.payload).toMatchObject({ causedBy: "leaf" });
+  });
+
+  it("stops the upward repair at the first unarchived ancestor", async () => {
+    // root(not archived) -> a(archived) -> leaf(archived); repair stops below root.
+    const at = new Date("2026-01-02");
+    db.task.findUnique.mockResolvedValue(
+      target({ id: "leaf", parentId: "a", archivedAt: at }),
+    );
+    ancestors([
+      row("a", "root", { archivedAt: at }),
+      row("root", null), // not archived → not repaired, no event
+    ]);
+
+    const result = await unarchiveTask({ taskId: "leaf", userId: USER });
+
+    expect(result.success).toBe(true);
+    expect(emitted().map((e) => e.taskId).sort()).toEqual(["a", "leaf"]);
+  });
+});
+
+describe("hierarchy transition — rollback on emit failure", () => {
+  it("propagates an emit failure out of the transaction (no swallowed success)", async () => {
+    // The emit rides the caller's tx, so a failing insert must abort the whole
+    // operation — the wiring that lets Prisma roll the state change back. (The
+    // actual atomic DB revert is Prisma's and is exercised end-to-end in verify.)
+    db.task.findUnique.mockResolvedValue(target());
+    tree([row("root", null), row("a", "root")]);
+    mockTx.taskEvent.create.mockRejectedValue(new Error("event insert failed"));
+
+    const result = await completeTask({ taskId: "root", userId: USER });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.code).toBe("INTERNAL_SERVER_ERROR");
+    }
+  });
+});
+
+describe("restoreDeletedTask — event emission (upward repair)", () => {
+  it("emits RESTORED on the target and each repaired ancestor (causedBy = target)", async () => {
+    // root(deleted) -> a(deleted) -> leaf(deleted); restore the leaf.
+    const at = new Date("2026-01-02");
+    db.task.findUnique.mockResolvedValue(
+      target({ id: "leaf", parentId: "a", deletedAt: at }),
+    );
+    ancestors([
+      row("a", "root", { deletedAt: at }),
+      row("root", null, { deletedAt: at }),
+    ]);
+
+    const result = await restoreDeletedTask({ taskId: "leaf", userId: USER });
+
+    expect(result.success).toBe(true);
+    const events = emitted();
+    expect(events.map((e) => e.taskId).sort()).toEqual(["a", "leaf", "root"]);
+    expect(events.every((e) => e.eventType === "RESTORED")).toBe(true);
+
+    const byTask = Object.fromEntries(events.map((e) => [e.taskId, e]));
+    expect(byTask.leaf.payload).not.toHaveProperty("causedBy");
+    expect(byTask.a.payload).toMatchObject({ causedBy: "leaf" });
+    expect(byTask.root.payload).toMatchObject({ causedBy: "leaf" });
+  });
+
+  it("stops the upward repair at the first non-deleted ancestor", async () => {
+    // root(not deleted) -> a(deleted) -> leaf(deleted); repair stops below root.
+    const at = new Date("2026-01-02");
+    db.task.findUnique.mockResolvedValue(
+      target({ id: "leaf", parentId: "a", deletedAt: at }),
+    );
+    ancestors([
+      row("a", "root", { deletedAt: at }),
+      row("root", null), // not deleted → not repaired, no event
+    ]);
+
+    const result = await restoreDeletedTask({ taskId: "leaf", userId: USER });
+
+    expect(result.success).toBe(true);
+    expect(emitted().map((e) => e.taskId).sort()).toEqual(["a", "leaf"]);
+  });
+});


### PR DESCRIPTION
## What

All six hierarchy transitions (`completeTask` / `uncompleteTask` / `archiveTask` / `unarchiveTask` / `deleteTask` / `restoreDeletedTask`) now emit one TaskEvent per affected task inside their existing transaction, per ADR-0020:

- Direct target: verb event with `{at}`, no `causedBy`.
- Every cascaded descendant / repaired ancestor: SAME verb type with `{at, causedBy: <target task id>}` — no twin types.
- Tasks pruned by the ADR-0018 / #44 stop rule undergo no state change and emit nothing.
- Actor `userId` = acting user on all events of one act; one shared `at` per act.
- Emission rides the transition transaction (`emitEvent(tx, …)`), so an emit failure rolls the state change back.

## Where

- `lib/services/task.service.ts` — new `emitTransitionEvents` helper (takes the already-pruned `TransitionPlan` slot) + one call after each of the six `executePlan` sites.
- `tests/helpers/prisma-mock.ts` — added missing `updateMany` mock method.
- `tests/unit/services/task.service.transitionEvents.test.ts` — new, 17 tests.

## Test evidence

- TDD (red-green per verb). Full suite: **166 passed** (149 baseline + 17 new), `tsc --noEmit` clean.
- Covers: leaf targets for complete/archive/delete (no `causedBy`), multi-level cascade (all descendants `causedBy` = direct target, not their parent), stop-rule pruning (linear + branching mixed tree: fresh branch cascades while in-state sibling branch stays silent), upward-repair chains incl. stop at first not-in-state ancestor for all three un-verbs, emit-failure propagation out of the transaction.

## Notes

- Upward repairs stamp repaired ancestors with `causedBy: <target>` too — issue text mentions `causedBy` only for descendants, but ADR-0020 + #23 ("cascades emit per affected task, same type, causedBy set") read as one rule for all indirectly-changed tasks; flagging in case that reading is off.
- Local `TransitionEventType` union re-lists the six verbs `event.service.ts` maps to `statusTransitionPayload`. Single-sourcing it means exporting from `event.service.ts`, which was frozen for parallel wiring work — worth a follow-up.

## Verify (real app, end-to-end)

Drove the REAL flow against the shared dev DB: throwaway account via `/api/create-account`, next-auth credentials login over HTTP, then all six server actions invoked over the socket (`Next-Action` POSTs) on a seeded 5-task tree (`root→{a→b, c*→d*}`, `*` = pre-completed stop-rule branch):

- `complete(root)` → 3 COMPLETED rows: root `{at}`, a+b `{at, causedBy: root}`; c/d silent, their `completedAt` dates NOT re-stamped.
- `uncomplete(b)` → b/a/root UNCOMPLETED (b direct, a+root `causedBy: b`).
- `archive(a)` → a/b ARCHIVED; `unarchive(b)` → b/a UNARCHIVED.
- `delete(root)` → all 5 DELETED (cascade through archived + completed subtrees).
- `restore(d)` → d/c/root RESTORED; `restore(b)` → b/a, stopping at already-restored root.
- Probes: complete-on-completed and unauthenticated calls → error responses, ledger unchanged (20 rows before = after; 20 = exactly 3+3+2+5+5+2).
- Fixture fully cleaned from the shared DB afterwards (0 leftover rows).

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)
