### PR TITLE
feat: Event Log integration — #51–#55 wired into main-vibe (#23)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -90,10 +90,10 @@ Derived from datetime flags, no enum (ADR-0007): `completedAt`, `archivedAt`, `d
 6. Soft-deleted rows filtered from every query.
 7. Toggl optional everywhere.
 
-## Current state (verified against code 2026-07-12)
+## Current state (verified against code 2026-07-14)
 
-- **Implemented**: auth, project/task CRUD, hierarchy transitions incl. archive/restore/undelete, timers (ActiveTimer→TimeEntry), soft delete, default project, sidebar layout, toast system.
-- **Modeled, not wired**: tags (schema + service params; zero UI, no tag CRUD — #5), TaskEvent emission (`event.service.ts` exists; zero `emitEvent` call sites in mutating services), checkpoint auto-triggers, analysis dashboard, TodoItem UI, Toggl integration.
+- **Implemented**: auth, project/task CRUD, hierarchy transitions incl. archive/restore/undelete, timers (ActiveTimer→TimeEntry), soft delete, default project, sidebar layout, toast system, TaskEvent emission (Iteration 2, #23: emitEvent in event.service.ts + wiring for CREATED/STARTED/ESTIMATE_CHANGED/SUBTASK_*/TAGS_CHANGED/hierarchy verbs; TODO_*/CHECKPOINT_CREATED types dormant).
+- **Modeled, not wired**: tags (schema + service params; zero UI, no tag CRUD — #5), checkpoint auto-triggers, analysis dashboard, TodoItem UI, Toggl integration.
 - Schema source of truth: `prisma/schema.prisma` — never trust a doc's schema copy over it.
 - Backlog + pending decisions: GitHub issues (`docs/agents/issue-tracker.md`).
 

--- a/lib/services/activeTask.service.ts
+++ b/lib/services/activeTask.service.ts
@@ -6,6 +6,7 @@ import {
   serviceQuery,
   serviceQueryOrNotFound,
 } from "./serviceUtil";
+import { emitStartedOnce } from "./startedEvent";
 import { calculateDurationInSeconds } from "../util";
 
 export function getActiveTimer({ userId }: { userId: string }) {
@@ -81,6 +82,9 @@ export function startActiveTimer({
       const newActiveTimer = await tx.activeTimer.create({
         data: { userId, taskId, startedAt: now },
       });
+
+      // Record the task's first work; no-op if a STARTED already exists (#55).
+      await emitStartedOnce(tx, { taskId, userId, startedAt: now });
 
       return { activeTimer: newActiveTimer, timeEntry: createdTimeEntry };
     });

--- a/lib/services/startedEvent.ts
+++ b/lib/services/startedEvent.ts
@@ -1,0 +1,41 @@
+import { Prisma, TaskEventType } from "@prisma/client";
+import { emitEvent } from "./event.service";
+
+/**
+ * Emit a write-once STARTED event marking a task's first work (#23/#55).
+ *
+ * Skips the emit when the ledger already holds a STARTED for the task, so later
+ * timers or manual entries — even backdated ones — never move or duplicate it:
+ * corrections live in state, not in past events (#23).
+ *
+ * Runs on the caller's transaction client, so the guard read and the insert
+ * commit (or roll back) together with the caller's mutation. Note the guard is
+ * best-effort under concurrency: without a unique constraint on
+ * (taskId, eventType), two transactions racing on the same task could each see
+ * "no prior STARTED" and both insert. Acceptable single-user; a partial unique
+ * index would close it if that ever matters.
+ *
+ * Belongs conceptually in event.service.ts; kept separate while #51–#55 land in
+ * parallel so that shared file stays untouched.
+ */
+export async function emitStartedOnce(
+  tx: Prisma.TransactionClient,
+  {
+    taskId,
+    userId,
+    startedAt,
+  }: { taskId: string; userId: string; startedAt: Date },
+) {
+  const priorStarted = await tx.taskEvent.findFirst({
+    where: { taskId, eventType: TaskEventType.STARTED },
+    select: { id: true },
+  });
+  if (priorStarted) return null;
+
+  return emitEvent(tx, {
+    taskId,
+    userId,
+    type: TaskEventType.STARTED,
+    payload: { startedAt },
+  });
+}

--- a/lib/services/task.service.ts
+++ b/lib/services/task.service.ts
@@ -1,5 +1,7 @@
+import { Prisma, TaskEventType } from "@prisma/client";
 import client from "@/lib/prisma";
 import { CreateTaskParams, UpdateTaskParams } from "../schema/task";
+import { emitEvent, type EmitEventInput } from "./event.service";
 import {
   createServiceErrorResponse,
   createSuccessResponseWithData,
@@ -91,6 +93,61 @@ async function executePlan(plan: TransitionPlan, tx: DbClient): Promise<void> {
       where: { id: { in: plan.setDeletedAt.ids } },
       data: { deletedAt: plan.setDeletedAt.value },
     });
+  }
+}
+
+/**
+ * The six hierarchy-transition verbs. All share `statusTransitionPayload`
+ * (`{at, causedBy?}`) in event.service, so a single payload shape is valid for
+ * whichever verb this helper is handed.
+ */
+type TransitionEventType =
+  | typeof TaskEventType.COMPLETED
+  | typeof TaskEventType.UNCOMPLETED
+  | typeof TaskEventType.ARCHIVED
+  | typeof TaskEventType.UNARCHIVED
+  | typeof TaskEventType.DELETED
+  | typeof TaskEventType.RESTORED;
+
+/**
+ * Emit one TaskEvent per task changed by a hierarchy transition (ADR-0020).
+ *
+ * `changed` is the transition plan's slot for the flag this verb touches. Its
+ * `ids` are already pruned, so descendants halted by the #44 stop rule — and any
+ * task the transition left unchanged — are absent and emit nothing. Its `value`
+ * is the stamped date, or null when the verb clears the flag (upward repairs) —
+ * then the event time is the act's time, now. The direct target (`targetTaskId`)
+ * gets `{at}`; every other changed task (a cascaded descendant, or an ancestor
+ * repaired by an upward transition) gets `{at, causedBy: targetTaskId}` under
+ * the SAME event `type`. Runs on the caller's `tx`, so a failure here rolls the
+ * whole transition back.
+ */
+async function emitTransitionEvents(
+  tx: Prisma.TransactionClient,
+  {
+    type,
+    userId,
+    targetTaskId,
+    changed,
+  }: {
+    type: TransitionEventType;
+    userId: string;
+    targetTaskId: string;
+    changed: { ids: string[]; value: Date | null };
+  },
+): Promise<void> {
+  const at = changed.value ?? new Date();
+  for (const id of changed.ids) {
+    // Every `TransitionEventType` maps to the same `statusTransitionPayload`, so
+    // this input satisfies whichever of the six arms `type` selects — TS checks
+    // that by distributing the literal over the extracted union, no cast needed.
+    const input: Extract<EmitEventInput, { type: TransitionEventType }> = {
+      taskId: id,
+      userId,
+      type,
+      payload: id === targetTaskId ? { at } : { at, causedBy: targetTaskId },
+    };
+    await emitEvent(tx, input);
   }
 }
 
@@ -307,6 +364,12 @@ export function deleteTask({
 
       const plan = buildTransitionPlan("DELETE", task, ancestors, descendants);
       await executePlan(plan, tx);
+      await emitTransitionEvents(tx, {
+        type: TaskEventType.DELETED,
+        userId,
+        targetTaskId: task.id,
+        changed: plan.setDeletedAt,
+      });
 
       return createSuccessResponseWithData({
         id: taskId,
@@ -397,6 +460,12 @@ export function completeTask({
         descendants,
       );
       await executePlan(plan, tx);
+      await emitTransitionEvents(tx, {
+        type: TaskEventType.COMPLETED,
+        userId,
+        targetTaskId: task.id,
+        changed: plan.setCompletedAt,
+      });
 
       return createSuccessResponseWithData({
         id: taskId,
@@ -451,6 +520,12 @@ export function uncompleteTask({
 
       const plan = buildTransitionPlan("UNCOMPLETE", task, ancestors);
       await executePlan(plan, tx);
+      await emitTransitionEvents(tx, {
+        type: TaskEventType.UNCOMPLETED,
+        userId,
+        targetTaskId: task.id,
+        changed: plan.setCompletedAt,
+      });
 
       return createSuccessResponseWithData({
         id: taskId,
@@ -526,6 +601,12 @@ export function archiveTask({
         descendants,
       );
       await executePlan(plan, tx);
+      await emitTransitionEvents(tx, {
+        type: TaskEventType.ARCHIVED,
+        userId,
+        targetTaskId: task.id,
+        changed: plan.setArchivedAt,
+      });
 
       return createSuccessResponseWithData({
         id: taskId,
@@ -577,6 +658,12 @@ export function unarchiveTask({
 
       const plan = buildTransitionPlan("UNARCHIVE", task, ancestors);
       await executePlan(plan, tx);
+      await emitTransitionEvents(tx, {
+        type: TaskEventType.UNARCHIVED,
+        userId,
+        targetTaskId: task.id,
+        changed: plan.setArchivedAt,
+      });
 
       return createSuccessResponseWithData({ id: taskId });
     });
@@ -625,6 +712,12 @@ export function restoreDeletedTask({
 
       const plan = buildTransitionPlan("UNDELETE", task, ancestors);
       await executePlan(plan, tx);
+      await emitTransitionEvents(tx, {
+        type: TaskEventType.RESTORED,
+        userId,
+        targetTaskId: task.id,
+        changed: plan.setDeletedAt,
+      });
 
       return createSuccessResponseWithData({
         id: taskId,

--- a/lib/services/task.service.ts
+++ b/lib/services/task.service.ts
@@ -1,5 +1,7 @@
+import { TaskEventType } from "@prisma/client";
 import client from "@/lib/prisma";
 import { CreateTaskParams, UpdateTaskParams } from "../schema/task";
+import { emitEvent } from "./event.service";
 import {
   createServiceErrorResponse,
   createSuccessResponseWithData,
@@ -163,29 +165,44 @@ export function createTask({
       }
     }
 
-    const task = await client.task.create({
-      data: {
-        title: createTaskParams.title,
-        description: createTaskParams.description,
-        estimate: createTaskParams.estimate,
-        project: { connect: { id: createTaskParams.projectId } },
-        createdBy: { connect: { id: userId } },
-        ...(createTaskParams.parentId
-          ? { parent: { connect: { id: createTaskParams.parentId } } }
-          : {}),
-        todoItems: {
-          create: createTaskParams.todoItems?.map((todo) => ({
-            title: todo.title,
-            estimate: todo.estimate,
-          })),
+    const task = await client.$transaction(async (tx) => {
+      const created = await tx.task.create({
+        data: {
+          title: createTaskParams.title,
+          description: createTaskParams.description,
+          estimate: createTaskParams.estimate,
+          project: { connect: { id: createTaskParams.projectId } },
+          createdBy: { connect: { id: userId } },
+          ...(createTaskParams.parentId
+            ? { parent: { connect: { id: createTaskParams.parentId } } }
+            : {}),
+          todoItems: {
+            create: createTaskParams.todoItems?.map((todo) => ({
+              title: todo.title,
+              estimate: todo.estimate,
+            })),
+          },
+          taskTags: {
+            create: createTaskParams.tagIds?.map((tagId) => ({
+              tag: { connect: { id: tagId } },
+              user: { connect: { id: userId } },
+            })),
+          },
         },
-        taskTags: {
-          create: createTaskParams.tagIds?.map((tagId) => ({
-            tag: { connect: { id: tagId } },
-            user: { connect: { id: userId } },
-          })),
-        },
-      },
+      });
+
+      // Record the new subtask on its direct parent's event trail (#52).
+      // Emitted on the parent only; creation has no cascade to exclude.
+      if (createTaskParams.parentId) {
+        await emitEvent(tx, {
+          taskId: createTaskParams.parentId,
+          userId,
+          type: TaskEventType.SUBTASK_CREATED,
+          payload: { childTaskId: created.id, childTitle: created.title },
+        });
+      }
+
+      return created;
     });
     return createSuccessResponseWithData(task);
   }, "Failed to create task");
@@ -257,6 +274,7 @@ export function deleteTask({
       where: { id: taskId, deletedAt: null },
       select: {
         id: true,
+        title: true, // for the SUBTASK_REMOVED payload on the parent (#52)
         parentId: true,
         projectId: true,
         completedAt: true,
@@ -307,6 +325,18 @@ export function deleteTask({
 
       const plan = buildTransitionPlan("DELETE", task, ancestors, descendants);
       await executePlan(plan, tx);
+
+      // Record the removal on the former direct parent's trail (#52). Only the
+      // directly-deleted task notifies its parent; descendants swept up by the
+      // same cascade do not emit (ADR-0020 boundary).
+      if (task.parentId) {
+        await emitEvent(tx, {
+          taskId: task.parentId,
+          userId,
+          type: TaskEventType.SUBTASK_REMOVED,
+          payload: { childTaskId: task.id, childTitle: task.title },
+        });
+      }
 
       return createSuccessResponseWithData({
         id: taskId,

--- a/lib/services/task.service.ts
+++ b/lib/services/task.service.ts
@@ -1,5 +1,7 @@
+import { TaskEventType } from "@prisma/client";
 import client from "@/lib/prisma";
 import { CreateTaskParams, UpdateTaskParams } from "../schema/task";
+import { emitEvent } from "./event.service";
 import {
   createServiceErrorResponse,
   createSuccessResponseWithData,
@@ -163,29 +165,51 @@ export function createTask({
       }
     }
 
-    const task = await client.task.create({
-      data: {
-        title: createTaskParams.title,
-        description: createTaskParams.description,
-        estimate: createTaskParams.estimate,
-        project: { connect: { id: createTaskParams.projectId } },
-        createdBy: { connect: { id: userId } },
-        ...(createTaskParams.parentId
-          ? { parent: { connect: { id: createTaskParams.parentId } } }
-          : {}),
-        todoItems: {
-          create: createTaskParams.todoItems?.map((todo) => ({
-            title: todo.title,
-            estimate: todo.estimate,
-          })),
+    const task = await client.$transaction(async (tx) => {
+      const created = await tx.task.create({
+        data: {
+          title: createTaskParams.title,
+          description: createTaskParams.description,
+          estimate: createTaskParams.estimate,
+          project: { connect: { id: createTaskParams.projectId } },
+          createdBy: { connect: { id: userId } },
+          ...(createTaskParams.parentId
+            ? { parent: { connect: { id: createTaskParams.parentId } } }
+            : {}),
+          todoItems: {
+            create: createTaskParams.todoItems?.map((todo) => ({
+              title: todo.title,
+              estimate: todo.estimate,
+            })),
+          },
+          taskTags: {
+            create: createTaskParams.tagIds?.map((tagId) => ({
+              tag: { connect: { id: tagId } },
+              user: { connect: { id: userId } },
+            })),
+          },
         },
-        taskTags: {
-          create: createTaskParams.tagIds?.map((tagId) => ({
-            tag: { connect: { id: tagId } },
-            user: { connect: { id: userId } },
-          })),
+      });
+
+      // CREATED marks the task's birth: title always, estimate/parentId only
+      // when set. A task born with an estimate is fully covered here — no
+      // separate ESTIMATE_CHANGED fires at creation (#51).
+      await emitEvent(tx, {
+        taskId: created.id,
+        userId,
+        type: TaskEventType.CREATED,
+        payload: {
+          title: createTaskParams.title,
+          ...(createTaskParams.estimate !== undefined
+            ? { estimate: createTaskParams.estimate }
+            : {}),
+          ...(createTaskParams.parentId
+            ? { parentId: createTaskParams.parentId }
+            : {}),
         },
-      },
+      });
+
+      return created;
     });
     return createSuccessResponseWithData(task);
   }, "Failed to create task");
@@ -204,7 +228,7 @@ export function updateTask({
   return serviceAction(async () => {
     const task = await client.task.findUnique({
       where: { id: updateTaskParams.id, deletedAt: null, archivedAt: null },
-      select: { project: { select: { userId: true } } },
+      select: { estimate: true, project: { select: { userId: true } } },
     });
     if (!task) {
       return createServiceErrorResponse("NOT_FOUND", "Task not found");
@@ -222,24 +246,46 @@ export function updateTask({
       );
     }
 
-    const updatedTask = await client.task.update({
-      where: { id: updateTaskParams.id },
-      data: {
-        title: updateTaskParams.title,
-        description: updateTaskParams.description,
-        estimate: updateTaskParams.estimate,
-        ...(updateTaskParams.tagIds !== null
-          ? {
-              taskTags: {
-                deleteMany: { userId },
-                create: updateTaskParams.tagIds.map((tagId) => ({
-                  tag: { connect: { id: tagId } },
-                  user: { connect: { id: userId } },
-                })),
-              },
-            }
-          : {}),
-      },
+    const oldEstimate = task.estimate;
+
+    const updatedTask = await client.$transaction(async (tx) => {
+      const updated = await tx.task.update({
+        where: { id: updateTaskParams.id },
+        data: {
+          title: updateTaskParams.title,
+          description: updateTaskParams.description,
+          estimate: updateTaskParams.estimate,
+          ...(updateTaskParams.tagIds !== null
+            ? {
+                taskTags: {
+                  deleteMany: { userId },
+                  create: updateTaskParams.tagIds.map((tagId) => ({
+                    tag: { connect: { id: tagId } },
+                    user: { connect: { id: userId } },
+                  })),
+                },
+              }
+            : {}),
+        },
+      });
+
+      // ESTIMATE_CHANGED fires only on a real change. `undefined` means the
+      // caller left estimate untouched (Prisma skips it), and an equal value is
+      // a no-op — neither belongs in the audit trail. `old` is nullable since
+      // the task may have had no estimate.
+      if (
+        updateTaskParams.estimate !== undefined &&
+        updateTaskParams.estimate !== oldEstimate
+      ) {
+        await emitEvent(tx, {
+          taskId: updateTaskParams.id,
+          userId,
+          type: TaskEventType.ESTIMATE_CHANGED,
+          payload: { old: oldEstimate, new: updateTaskParams.estimate },
+        });
+      }
+
+      return updated;
     });
     return createSuccessResponseWithData(updatedTask);
   }, "Failed to update task");

--- a/lib/services/timeEntry.service.ts
+++ b/lib/services/timeEntry.service.ts
@@ -4,6 +4,7 @@ import {
   createSuccessResponseWithData,
   serviceAction,
 } from "./serviceUtil";
+import { emitStartedOnce } from "./startedEvent";
 import { calculateDurationInSeconds } from "../util";
 
 // ─── Reads ─────────────────────────────────────────────────────────────────────
@@ -61,14 +62,24 @@ export function createManualTimeEntry({
         "User does not have access to this task",
       );
 
-    const entry = await client.timeEntry.create({
-      data: {
-        task: { connect: { id: taskId } },
-        user: { connect: { id: userId } },
-        startedAt,
-        stoppedAt,
-        duration: calculateDurationInSeconds(startedAt, stoppedAt),
-      },
+    // Transaction so the entry and any first-work STARTED event commit together
+    // (emit failure rolls back the entry). This path was single-statement before #55.
+    const entry = await client.$transaction(async (tx) => {
+      const created = await tx.timeEntry.create({
+        data: {
+          task: { connect: { id: taskId } },
+          user: { connect: { id: userId } },
+          startedAt,
+          stoppedAt,
+          duration: calculateDurationInSeconds(startedAt, stoppedAt),
+        },
+      });
+
+      // Record the task's first work; no-op if a STARTED already exists —
+      // a backdated entry never moves or re-emits it (#55).
+      await emitStartedOnce(tx, { taskId, userId, startedAt });
+
+      return created;
     });
 
     return createSuccessResponseWithData(entry);

--- a/tests/helpers/prisma-mock.ts
+++ b/tests/helpers/prisma-mock.ts
@@ -7,6 +7,7 @@ function mockMethods() {
     findMany: vi.fn(),
     create: vi.fn(),
     update: vi.fn(),
+    updateMany: vi.fn(),
     delete: vi.fn(),
     deleteMany: vi.fn(),
     count: vi.fn(),

--- a/tests/unit/services/activeTask.service.test.ts
+++ b/tests/unit/services/activeTask.service.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TaskEventType } from "@prisma/client";
 import {
   createMockPrismaClient,
   mockTx,
@@ -208,6 +209,71 @@ describe("startActiveTimer", () => {
     const createTimerOrder = tx.activeTimer.create.mock.invocationCallOrder[0];
     expect(createEntryOrder).toBeLessThan(deleteTimerOrder);
     expect(deleteTimerOrder).toBeLessThan(createTimerOrder);
+  });
+});
+
+describe("startActiveTimer — STARTED event", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db.$transaction.mockImplementation((fn) => fn(tx));
+    db.task.findUnique.mockResolvedValue(
+      buildTask({ createdById: "test-user-1" }),
+    );
+    tx.activeTimer.findUnique.mockResolvedValue(null);
+    tx.activeTimer.create.mockResolvedValue(buildActiveTimer());
+  });
+
+  it("emits STARTED with the start time on the task's first work", async () => {
+    tx.taskEvent.findFirst.mockResolvedValue(null); // no prior STARTED
+
+    await startActiveTimer({ userId: "test-user-1", taskId: "test-task-1" });
+
+    expect(tx.taskEvent.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          taskId: "test-task-1",
+          userId: "test-user-1",
+          eventType: TaskEventType.STARTED,
+          // stored as an ISO-8601 string by emitEvent's timestamp transform
+          payload: { startedAt: expect.any(String) },
+        }),
+      }),
+    );
+  });
+
+  it("does not emit a second STARTED when the task already has one", async () => {
+    tx.taskEvent.findFirst.mockResolvedValue({ id: "existing-started" });
+
+    await startActiveTimer({ userId: "test-user-1", taskId: "test-task-1" });
+
+    expect(tx.taskEvent.create).not.toHaveBeenCalled();
+  });
+
+  it("scopes the prior-STARTED guard to this task and event type", async () => {
+    tx.taskEvent.findFirst.mockResolvedValue(null);
+
+    await startActiveTimer({ userId: "test-user-1", taskId: "test-task-1" });
+
+    expect(tx.taskEvent.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          taskId: "test-task-1",
+          eventType: TaskEventType.STARTED,
+        }),
+      }),
+    );
+  });
+
+  it("fails the action (rolls back) when the STARTED emit throws", async () => {
+    tx.taskEvent.findFirst.mockResolvedValue(null);
+    tx.taskEvent.create.mockRejectedValue(new Error("emit failed"));
+
+    const result = await startActiveTimer({
+      userId: "test-user-1",
+      taskId: "test-task-1",
+    });
+
+    expect(result.success).toBe(false);
   });
 });
 

--- a/tests/unit/services/task.service.test.ts
+++ b/tests/unit/services/task.service.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TaskEventType } from "@prisma/client";
 import {
   createMockPrismaClient,
+  mockTx,
   type MockPrismaClient,
+  type MockTx,
 } from "@/tests/helpers/prisma-mock";
 import { buildTask, buildActiveTimer } from "@/tests/helpers/factories";
 
@@ -10,10 +13,15 @@ vi.mock("@/lib/prisma", () => {
   return { default: mock };
 });
 
-import { hasActiveDescendants } from "@/lib/services/task.service";
+import {
+  hasActiveDescendants,
+  createTask,
+  updateTask,
+} from "@/lib/services/task.service";
 import prisma from "@/lib/prisma";
 
 const db = prisma as unknown as MockPrismaClient;
+const tx = mockTx as MockTx;
 
 describe("hasActiveTimers", () => {
   beforeEach(() => {
@@ -103,5 +111,203 @@ describe("hasActiveTimers", () => {
     expect(db.activeTimer.findFirst).toHaveBeenCalledWith({
       where: { taskId: { in: ["task-1", "task-2", "task-3"] } },
     });
+  });
+});
+
+describe("createTask", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db.$transaction.mockImplementation((fn: (client: MockTx) => unknown) =>
+      fn(tx),
+    );
+    db.project.findUnique.mockResolvedValue({ userId: "test-user-1" });
+    tx.taskEvent.create.mockResolvedValue({ id: "event-1" });
+  });
+
+  it("emits one CREATED event carrying title, estimate, and parentId, in the transaction", async () => {
+    // Parent-existence check inside createTask
+    db.task.findUnique.mockResolvedValue({ id: "parent-1" });
+    tx.task.create.mockResolvedValue(
+      buildTask({ id: "task-1", parentId: "parent-1", estimate: 60 }),
+    );
+
+    const result = await createTask({
+      userId: "test-user-1",
+      createTaskParams: {
+        projectId: "project-1",
+        parentId: "parent-1",
+        title: "Write the docs",
+        estimate: 60,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(tx.taskEvent.create).toHaveBeenCalledTimes(1);
+    expect(tx.taskEvent.create).toHaveBeenCalledWith({
+      data: {
+        taskId: "task-1",
+        userId: "test-user-1",
+        eventType: TaskEventType.CREATED,
+        payload: {
+          title: "Write the docs",
+          estimate: 60,
+          parentId: "parent-1",
+        },
+      },
+    });
+  });
+
+  it("emits CREATED with only a title when the task has no estimate and no parent", async () => {
+    tx.task.create.mockResolvedValue(
+      buildTask({ id: "task-2", parentId: null, estimate: null }),
+    );
+
+    const result = await createTask({
+      userId: "test-user-1",
+      createTaskParams: {
+        projectId: "project-1",
+        parentId: null,
+        title: "Solo task",
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(tx.taskEvent.create).toHaveBeenCalledWith({
+      data: {
+        taskId: "task-2",
+        userId: "test-user-1",
+        eventType: TaskEventType.CREATED,
+        payload: { title: "Solo task" },
+      },
+    });
+  });
+
+  it("does not emit ESTIMATE_CHANGED at creation, even when born with an estimate", async () => {
+    tx.task.create.mockResolvedValue(
+      buildTask({ id: "task-3", parentId: null, estimate: 90 }),
+    );
+
+    await createTask({
+      userId: "test-user-1",
+      createTaskParams: {
+        projectId: "project-1",
+        parentId: null,
+        title: "Estimated at birth",
+        estimate: 90,
+      },
+    });
+
+    // Exactly one event, and it is CREATED — so no ESTIMATE_CHANGED rode along.
+    expect(tx.taskEvent.create).toHaveBeenCalledTimes(1);
+    expect(tx.taskEvent.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ eventType: TaskEventType.CREATED }),
+      }),
+    );
+  });
+});
+
+describe("updateTask", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db.$transaction.mockImplementation((fn: (client: MockTx) => unknown) =>
+      fn(tx),
+    );
+    tx.taskEvent.create.mockResolvedValue({ id: "event-1" });
+  });
+
+  it("emits ESTIMATE_CHANGED with old and new when the estimate changes", async () => {
+    db.task.findUnique.mockResolvedValue({
+      estimate: 60,
+      project: { userId: "test-user-1" },
+    });
+    tx.task.update.mockResolvedValue(buildTask({ id: "task-1", estimate: 120 }));
+
+    const result = await updateTask({
+      userId: "test-user-1",
+      updateTaskParams: {
+        id: "task-1",
+        title: "Updated title",
+        estimate: 120,
+        tagIds: null,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(tx.taskEvent.create).toHaveBeenCalledTimes(1);
+    expect(tx.taskEvent.create).toHaveBeenCalledWith({
+      data: {
+        taskId: "task-1",
+        userId: "test-user-1",
+        eventType: TaskEventType.ESTIMATE_CHANGED,
+        payload: { old: 60, new: 120 },
+      },
+    });
+  });
+
+  it("emits ESTIMATE_CHANGED with old null when setting an estimate on a task that had none", async () => {
+    db.task.findUnique.mockResolvedValue({
+      estimate: null,
+      project: { userId: "test-user-1" },
+    });
+    tx.task.update.mockResolvedValue(buildTask({ id: "task-1", estimate: 45 }));
+
+    await updateTask({
+      userId: "test-user-1",
+      updateTaskParams: {
+        id: "task-1",
+        title: "Now estimated",
+        estimate: 45,
+        tagIds: null,
+      },
+    });
+
+    expect(tx.taskEvent.create).toHaveBeenCalledWith({
+      data: {
+        taskId: "task-1",
+        userId: "test-user-1",
+        eventType: TaskEventType.ESTIMATE_CHANGED,
+        payload: { old: null, new: 45 },
+      },
+    });
+  });
+
+  it("does not emit ESTIMATE_CHANGED when the estimate is not part of the update", async () => {
+    db.task.findUnique.mockResolvedValue({
+      estimate: 60,
+      project: { userId: "test-user-1" },
+    });
+    tx.task.update.mockResolvedValue(buildTask({ id: "task-1", estimate: 60 }));
+
+    await updateTask({
+      userId: "test-user-1",
+      updateTaskParams: {
+        id: "task-1",
+        title: "Only the title changed",
+        tagIds: null,
+      },
+    });
+
+    expect(tx.taskEvent.create).not.toHaveBeenCalled();
+  });
+
+  it("does not emit ESTIMATE_CHANGED when the estimate is unchanged", async () => {
+    db.task.findUnique.mockResolvedValue({
+      estimate: 60,
+      project: { userId: "test-user-1" },
+    });
+    tx.task.update.mockResolvedValue(buildTask({ id: "task-1", estimate: 60 }));
+
+    await updateTask({
+      userId: "test-user-1",
+      updateTaskParams: {
+        id: "task-1",
+        title: "Re-saved with same estimate",
+        estimate: 60,
+        tagIds: null,
+      },
+    });
+
+    expect(tx.taskEvent.create).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/services/task.service.test.ts
+++ b/tests/unit/services/task.service.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TaskEventType } from "@prisma/client";
 import {
   createMockPrismaClient,
+  mockTx,
   type MockPrismaClient,
+  type MockTx,
 } from "@/tests/helpers/prisma-mock";
 import { buildTask, buildActiveTimer } from "@/tests/helpers/factories";
 
@@ -10,10 +13,38 @@ vi.mock("@/lib/prisma", () => {
   return { default: mock };
 });
 
-import { hasActiveDescendants } from "@/lib/services/task.service";
+import {
+  hasActiveDescendants,
+  createTask,
+  deleteTask,
+  completeTask,
+  archiveTask,
+} from "@/lib/services/task.service";
 import prisma from "@/lib/prisma";
 
 const db = prisma as unknown as MockPrismaClient;
+const tx = mockTx as MockTx;
+
+// Subtask events are asserted by filtering for the specific eventType, never by
+// "taskEvent.create was never called" — sibling tickets (#51 CREATED, #54
+// DELETED) add other events on these same paths, and these assertions must stay
+// green after those merges.
+const subtaskEventCalls = (type: TaskEventType) =>
+  tx.taskEvent.create.mock.calls.filter(
+    (call: unknown[]) =>
+      (call[0] as { data?: { eventType?: TaskEventType } } | undefined)?.data
+        ?.eventType === type,
+  );
+
+// Minimal LineageNode row as returned by the hierarchy fetches
+// (getAllAncestors / collectDescendantNodes selects).
+const lineageNode = (id: string, parentId: string | null) => ({
+  id,
+  parentId,
+  completedAt: null,
+  archivedAt: null,
+  deletedAt: null,
+});
 
 describe("hasActiveTimers", () => {
   beforeEach(() => {
@@ -103,5 +134,219 @@ describe("hasActiveTimers", () => {
     expect(db.activeTimer.findFirst).toHaveBeenCalledWith({
       where: { taskId: { in: ["task-1", "task-2", "task-3"] } },
     });
+  });
+});
+
+describe("createTask — SUBTASK_CREATED events", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db.$transaction.mockImplementation((fn: (tx: MockTx) => unknown) => fn(tx));
+    tx.taskEvent.create.mockResolvedValue({ id: "event-1" });
+  });
+
+  it("emits SUBTASK_CREATED on the direct parent when a subtask is created under it", async () => {
+    db.project.findUnique.mockResolvedValue({ userId: "test-user-1" });
+    db.task.findUnique.mockResolvedValue({ id: "parent-1" }); // parent existence check
+    tx.task.create.mockResolvedValue(
+      buildTask({ id: "child-1", title: "Child task", parentId: "parent-1" }),
+    );
+
+    const result = await createTask({
+      userId: "test-user-1",
+      createTaskParams: {
+        projectId: "test-project-1",
+        parentId: "parent-1",
+        title: "Child task",
+      },
+    });
+
+    expect(result.success).toBe(true);
+    // Exactly one SUBTASK_CREATED, targeting the direct parent — not the new
+    // task itself, not any ancestor above the parent.
+    const createdEvents = subtaskEventCalls(TaskEventType.SUBTASK_CREATED);
+    expect(createdEvents).toHaveLength(1);
+    expect(createdEvents[0][0]).toEqual({
+      data: {
+        taskId: "parent-1",
+        userId: "test-user-1",
+        eventType: TaskEventType.SUBTASK_CREATED,
+        payload: { childTaskId: "child-1", childTitle: "Child task" },
+      },
+    });
+  });
+
+  it("does not emit SUBTASK_CREATED when a top-level task is created without a parent", async () => {
+    db.project.findUnique.mockResolvedValue({ userId: "test-user-1" });
+    tx.task.create.mockResolvedValue(
+      buildTask({ id: "root-1", title: "Root task", parentId: null }),
+    );
+
+    const result = await createTask({
+      userId: "test-user-1",
+      createTaskParams: {
+        projectId: "test-project-1",
+        parentId: null,
+        title: "Root task",
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(subtaskEventCalls(TaskEventType.SUBTASK_CREATED)).toHaveLength(0);
+  });
+});
+
+describe("deleteTask — SUBTASK_REMOVED events", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db.$transaction.mockImplementation((fn: (tx: MockTx) => unknown) => fn(tx));
+    tx.activeTimer.findFirst.mockResolvedValue(null);
+    tx.task.updateMany.mockResolvedValue({ count: 1 });
+    tx.taskEvent.create.mockResolvedValue({ id: "event-1" });
+  });
+
+  it("emits SUBTASK_REMOVED on the former direct parent when a subtask is deleted", async () => {
+    db.task.findUnique.mockResolvedValue(
+      buildTask({
+        id: "child-1",
+        title: "Child task",
+        parentId: "parent-1",
+        project: { userId: "test-user-1" },
+      }),
+    );
+    // getAllAncestors → parent-1 is a root (no further parent)
+    tx.task.findUnique.mockResolvedValue(lineageNode("parent-1", null));
+    // collectDescendantNodes → child-1 is a leaf
+    tx.task.findMany.mockResolvedValue([lineageNode("child-1", "parent-1")]);
+
+    const result = await deleteTask({
+      taskId: "child-1",
+      userId: "test-user-1",
+    });
+
+    expect(result.success).toBe(true);
+    expect(tx.taskEvent.create).toHaveBeenCalledWith({
+      data: {
+        taskId: "parent-1",
+        userId: "test-user-1",
+        eventType: TaskEventType.SUBTASK_REMOVED,
+        payload: { childTaskId: "child-1", childTitle: "Child task" },
+      },
+    });
+  });
+
+  it("emits no SUBTASK_REMOVED when deleting a top-level subtree (cascade only)", async () => {
+    // Deleting a root task cascades to its descendants; none of those cascaded
+    // removals emit, and the root itself has no parent to notify.
+    db.task.findUnique.mockResolvedValue(
+      buildTask({
+        id: "parent-1",
+        title: "Parent",
+        parentId: null,
+        project: { userId: "test-user-1" },
+      }),
+    );
+    tx.task.findMany.mockResolvedValue([
+      lineageNode("parent-1", null),
+      lineageNode("child-1", "parent-1"),
+      lineageNode("grandchild-1", "child-1"),
+    ]);
+
+    const result = await deleteTask({
+      taskId: "parent-1",
+      userId: "test-user-1",
+    });
+
+    expect(result.success).toBe(true);
+    expect(subtaskEventCalls(TaskEventType.SUBTASK_REMOVED)).toHaveLength(0);
+  });
+
+  it("emits SUBTASK_REMOVED for the directly-deleted task only, never its cascaded children", async () => {
+    // Delete a mid-level task that has both a parent (top-1) and a child
+    // (grandchild-1). Only the direct removal (middle-1 from top-1) emits.
+    db.task.findUnique.mockResolvedValue(
+      buildTask({
+        id: "middle-1",
+        title: "Middle",
+        parentId: "top-1",
+        project: { userId: "test-user-1" },
+      }),
+    );
+    tx.task.findUnique.mockResolvedValue(lineageNode("top-1", null));
+    tx.task.findMany.mockResolvedValue([
+      lineageNode("middle-1", "top-1"),
+      lineageNode("grandchild-1", "middle-1"),
+    ]);
+
+    await deleteTask({ taskId: "middle-1", userId: "test-user-1" });
+
+    const removed = subtaskEventCalls(TaskEventType.SUBTASK_REMOVED);
+    expect(removed).toHaveLength(1);
+    expect(removed[0][0]).toEqual({
+      data: {
+        taskId: "top-1",
+        userId: "test-user-1",
+        eventType: TaskEventType.SUBTASK_REMOVED,
+        payload: { childTaskId: "middle-1", childTitle: "Middle" },
+      },
+    });
+    // Never for the cascaded grandchild.
+    expect(tx.taskEvent.create).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          eventType: TaskEventType.SUBTASK_REMOVED,
+          payload: expect.objectContaining({ childTaskId: "grandchild-1" }),
+        }),
+      }),
+    );
+  });
+});
+
+describe("completeTask / archiveTask — no subtask events on cascades", () => {
+  // AC #52: cascading operations (complete/archive on a subtree) never emit
+  // SUBTASK_CREATED/SUBTASK_REMOVED. Assertions filter for the two subtask
+  // types only, so they stay green once #54 wires COMPLETED/ARCHIVED events
+  // onto these same paths.
+  const subtree = [
+    lineageNode("parent-1", null),
+    lineageNode("child-1", "parent-1"),
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db.$transaction.mockImplementation((fn: (tx: MockTx) => unknown) => fn(tx));
+    tx.activeTimer.findFirst.mockResolvedValue(null);
+    tx.task.updateMany.mockResolvedValue({ count: 2 });
+    tx.taskEvent.create.mockResolvedValue({ id: "event-1" });
+    db.task.findUnique.mockResolvedValue(
+      buildTask({
+        id: "parent-1",
+        title: "Parent",
+        parentId: null,
+        project: { userId: "test-user-1" },
+      }),
+    );
+    tx.task.findMany.mockResolvedValue(subtree);
+  });
+
+  it("completing a subtree emits no SUBTASK_CREATED/SUBTASK_REMOVED", async () => {
+    const result = await completeTask({
+      taskId: "parent-1",
+      userId: "test-user-1",
+    });
+
+    expect(result.success).toBe(true);
+    expect(subtaskEventCalls(TaskEventType.SUBTASK_CREATED)).toHaveLength(0);
+    expect(subtaskEventCalls(TaskEventType.SUBTASK_REMOVED)).toHaveLength(0);
+  });
+
+  it("archiving a subtree emits no SUBTASK_CREATED/SUBTASK_REMOVED", async () => {
+    const result = await archiveTask({
+      taskId: "parent-1",
+      userId: "test-user-1",
+    });
+
+    expect(result.success).toBe(true);
+    expect(subtaskEventCalls(TaskEventType.SUBTASK_CREATED)).toHaveLength(0);
+    expect(subtaskEventCalls(TaskEventType.SUBTASK_REMOVED)).toHaveLength(0);
   });
 });

--- a/tests/unit/services/task.service.transitionEvents.test.ts
+++ b/tests/unit/services/task.service.transitionEvents.test.ts
@@ -1,0 +1,433 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  createMockPrismaClient,
+  mockTx,
+  type MockPrismaClient,
+} from "@/tests/helpers/prisma-mock";
+import { buildTask } from "@/tests/helpers/factories";
+
+vi.mock("@/lib/prisma", () => {
+  const mock = createMockPrismaClient();
+  return { default: mock };
+});
+
+import {
+  completeTask,
+  archiveTask,
+  deleteTask,
+  uncompleteTask,
+  unarchiveTask,
+  restoreDeletedTask,
+} from "@/lib/services/task.service";
+import prisma from "@/lib/prisma";
+
+const db = prisma as unknown as MockPrismaClient;
+
+const USER = "test-user-1";
+const PROJECT = "test-project-1";
+
+type Row = {
+  id: string;
+  parentId: string | null;
+  completedAt: Date | null;
+  archivedAt: Date | null;
+  deletedAt: Date | null;
+};
+
+function row(
+  id: string,
+  parentId: string | null,
+  overrides: Partial<Row> = {},
+): Row {
+  return {
+    id,
+    parentId,
+    completedAt: null,
+    archivedAt: null,
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+/** The target task as returned by the outer `client.task.findUnique`. */
+function target(overrides: Partial<Row> = {}) {
+  return buildTask({
+    id: "root",
+    parentId: null,
+    projectId: PROJECT,
+    project: { userId: USER },
+    ...overrides,
+  });
+}
+
+/** Rows the in-transaction descendant scan (`tx.task.findMany`) returns. */
+function tree(rows: Row[]) {
+  mockTx.task.findMany.mockResolvedValue(rows);
+  mockTx.activeTimer.findFirst.mockResolvedValue(null);
+}
+
+/**
+ * Rows the in-transaction ancestor walk (`tx.task.findUnique`, one call per
+ * parent) returns, keyed by id. Used by the upward-repair transitions.
+ */
+function ancestors(rows: Row[]) {
+  const map = new Map(rows.map((r) => [r.id, r]));
+  mockTx.task.findUnique.mockImplementation((args: { where: { id: string } }) =>
+    Promise.resolve(map.get(args.where.id) ?? null),
+  );
+}
+
+/** TaskEvent rows written during the call, in emission order. */
+function emitted() {
+  return mockTx.taskEvent.create.mock.calls.map(
+    (c) => (c[0] as { data: Record<string, unknown> }).data,
+  );
+}
+
+beforeEach(() => {
+  // clearAllMocks resets call history but NOT implementations, so re-establish
+  // happy-path defaults here — otherwise a test that makes an insert reject (see
+  // the rollback case) or configures ancestors would leak into later tests.
+  vi.clearAllMocks();
+  mockTx.taskEvent.create.mockResolvedValue({});
+  mockTx.task.findUnique.mockResolvedValue(null); // no ancestors unless a test sets them
+});
+
+describe("completeTask — event emission", () => {
+  it("emits COMPLETED on a leaf target with no causedBy", async () => {
+    db.task.findUnique.mockResolvedValue(target());
+    tree([row("root", null)]);
+
+    const result = await completeTask({ taskId: "root", userId: USER });
+
+    expect(result.success).toBe(true);
+    const events = emitted();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      taskId: "root",
+      userId: USER,
+      eventType: "COMPLETED",
+      payload: { at: expect.any(String) },
+    });
+    expect(events[0].payload).not.toHaveProperty("causedBy");
+  });
+
+  it("cascades COMPLETED to every descendant with causedBy = the direct target", async () => {
+    // root -> a -> b, none completed
+    db.task.findUnique.mockResolvedValue(target());
+    tree([row("root", null), row("a", "root"), row("b", "a")]);
+
+    const result = await completeTask({ taskId: "root", userId: USER });
+
+    expect(result.success).toBe(true);
+    const events = emitted();
+    expect(events).toHaveLength(3);
+
+    const byTask = Object.fromEntries(events.map((e) => [e.taskId, e]));
+    expect(byTask.root).toMatchObject({ eventType: "COMPLETED" });
+    expect(byTask.root.payload).not.toHaveProperty("causedBy");
+    // Even the deep descendant points at the direct target, not its parent.
+    expect(byTask.a.payload).toMatchObject({ causedBy: "root" });
+    expect(byTask.b.payload).toMatchObject({ causedBy: "root" });
+    // Same verb type for direct act and cascade.
+    expect(events.every((e) => e.eventType === "COMPLETED")).toBe(true);
+    // One shared timestamp for the single authorized act.
+    const ats = new Set(events.map((e) => (e.payload as { at: string }).at));
+    expect(ats.size).toBe(1);
+  });
+
+  it("emits nothing for a subtree pruned by the #44 stop rule", async () => {
+    // root -> a(completed) -> b : a is already completed, so a and b are pruned.
+    db.task.findUnique.mockResolvedValue(target());
+    tree([
+      row("root", null),
+      row("a", "root", { completedAt: new Date("2026-01-02") }),
+      row("b", "a"),
+    ]);
+
+    const result = await completeTask({ taskId: "root", userId: USER });
+
+    expect(result.success).toBe(true);
+    const events = emitted();
+    expect(events.map((e) => e.taskId)).toEqual(["root"]);
+  });
+
+  it("mixed branching tree: fresh branch cascades while the in-state sibling branch stays silent", async () => {
+    // root ─┬─ a ─ b          (fresh → cascade, causedBy = root)
+    //       └─ c* ─ d*        (already completed → pruned, no events)
+    const done = new Date("2026-01-02");
+    db.task.findUnique.mockResolvedValue(target());
+    tree([
+      row("root", null),
+      row("a", "root"),
+      row("b", "a"),
+      row("c", "root", { completedAt: done }),
+      row("d", "c", { completedAt: done }),
+    ]);
+
+    const result = await completeTask({ taskId: "root", userId: USER });
+
+    expect(result.success).toBe(true);
+    const events = emitted();
+    expect(events.map((e) => e.taskId).sort()).toEqual(["a", "b", "root"]);
+    expect(events.every((e) => e.eventType === "COMPLETED")).toBe(true);
+
+    const byTask = Object.fromEntries(events.map((e) => [e.taskId, e]));
+    expect(byTask.root.payload).not.toHaveProperty("causedBy");
+    expect(byTask.a.payload).toMatchObject({ causedBy: "root" });
+    expect(byTask.b.payload).toMatchObject({ causedBy: "root" });
+  });
+});
+
+describe("archiveTask — event emission", () => {
+  it("emits ARCHIVED on a leaf target with no causedBy", async () => {
+    db.task.findUnique.mockResolvedValue(target());
+    tree([row("root", null)]);
+
+    const result = await archiveTask({ taskId: "root", userId: USER });
+
+    expect(result.success).toBe(true);
+    const events = emitted();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      taskId: "root",
+      userId: USER,
+      eventType: "ARCHIVED",
+      payload: { at: expect.any(String) },
+    });
+    expect(events[0].payload).not.toHaveProperty("causedBy");
+  });
+
+  it("cascades ARCHIVED to descendants; direct target has no causedBy", async () => {
+    // root -> a -> b, none archived
+    db.task.findUnique.mockResolvedValue(target());
+    tree([row("root", null), row("a", "root"), row("b", "a")]);
+
+    const result = await archiveTask({ taskId: "root", userId: USER });
+
+    expect(result.success).toBe(true);
+    const events = emitted();
+    expect(events).toHaveLength(3);
+    expect(events.every((e) => e.eventType === "ARCHIVED")).toBe(true);
+
+    const byTask = Object.fromEntries(events.map((e) => [e.taskId, e]));
+    expect(byTask.root.payload).not.toHaveProperty("causedBy");
+    expect(byTask.a.payload).toMatchObject({ causedBy: "root" });
+    expect(byTask.b.payload).toMatchObject({ causedBy: "root" });
+  });
+
+  it("emits nothing for a subtree pruned by the stop rule", async () => {
+    // root -> a(archived) -> b : a already archived, so a and b are pruned.
+    db.task.findUnique.mockResolvedValue(target());
+    tree([
+      row("root", null),
+      row("a", "root", { archivedAt: new Date("2026-01-02") }),
+      row("b", "a"),
+    ]);
+
+    const result = await archiveTask({ taskId: "root", userId: USER });
+
+    expect(result.success).toBe(true);
+    expect(emitted().map((e) => e.taskId)).toEqual(["root"]);
+  });
+});
+
+describe("deleteTask — event emission", () => {
+  it("emits DELETED on a leaf target with no causedBy", async () => {
+    db.task.findUnique.mockResolvedValue(target());
+    tree([row("root", null)]);
+
+    const result = await deleteTask({ taskId: "root", userId: USER });
+
+    expect(result.success).toBe(true);
+    const events = emitted();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      taskId: "root",
+      userId: USER,
+      eventType: "DELETED",
+      payload: { at: expect.any(String) },
+    });
+    expect(events[0].payload).not.toHaveProperty("causedBy");
+  });
+
+  it("cascades DELETED to descendants; direct target has no causedBy", async () => {
+    // root -> a -> b, none deleted
+    db.task.findUnique.mockResolvedValue(target());
+    tree([row("root", null), row("a", "root"), row("b", "a")]);
+
+    const result = await deleteTask({ taskId: "root", userId: USER });
+
+    expect(result.success).toBe(true);
+    const events = emitted();
+    expect(events).toHaveLength(3);
+    expect(events.every((e) => e.eventType === "DELETED")).toBe(true);
+
+    const byTask = Object.fromEntries(events.map((e) => [e.taskId, e]));
+    expect(byTask.root.payload).not.toHaveProperty("causedBy");
+    expect(byTask.a.payload).toMatchObject({ causedBy: "root" });
+    expect(byTask.b.payload).toMatchObject({ causedBy: "root" });
+  });
+
+  it("emits nothing for a subtree pruned by the stop rule", async () => {
+    // root -> a(deleted) -> b : a already deleted, so a and b are pruned.
+    db.task.findUnique.mockResolvedValue(target());
+    tree([
+      row("root", null),
+      row("a", "root", { deletedAt: new Date("2026-01-02") }),
+      row("b", "a"),
+    ]);
+
+    const result = await deleteTask({ taskId: "root", userId: USER });
+
+    expect(result.success).toBe(true);
+    expect(emitted().map((e) => e.taskId)).toEqual(["root"]);
+  });
+});
+
+describe("uncompleteTask — event emission (upward repair)", () => {
+  it("emits UNCOMPLETED on the target and each repaired ancestor (causedBy = target)", async () => {
+    // root(completed) -> a(completed) -> leaf(completed); uncomplete the leaf.
+    const done = new Date("2026-01-02");
+    db.task.findUnique.mockResolvedValue(
+      target({ id: "leaf", parentId: "a", completedAt: done }),
+    );
+    ancestors([
+      row("a", "root", { completedAt: done }),
+      row("root", null, { completedAt: done }),
+    ]);
+
+    const result = await uncompleteTask({ taskId: "leaf", userId: USER });
+
+    expect(result.success).toBe(true);
+    const events = emitted();
+    expect(events.map((e) => e.taskId).sort()).toEqual(["a", "leaf", "root"]);
+    expect(events.every((e) => e.eventType === "UNCOMPLETED")).toBe(true);
+
+    const byTask = Object.fromEntries(events.map((e) => [e.taskId, e]));
+    expect(byTask.leaf.payload).not.toHaveProperty("causedBy");
+    expect(byTask.a.payload).toMatchObject({ causedBy: "leaf" });
+    expect(byTask.root.payload).toMatchObject({ causedBy: "leaf" });
+  });
+
+  it("stops the upward repair at the first uncompleted ancestor", async () => {
+    // root(uncompleted) -> a(completed) -> leaf(completed); repair stops below root.
+    const done = new Date("2026-01-02");
+    db.task.findUnique.mockResolvedValue(
+      target({ id: "leaf", parentId: "a", completedAt: done }),
+    );
+    ancestors([
+      row("a", "root", { completedAt: done }),
+      row("root", null), // not completed → not repaired, no event
+    ]);
+
+    const result = await uncompleteTask({ taskId: "leaf", userId: USER });
+
+    expect(result.success).toBe(true);
+    expect(emitted().map((e) => e.taskId).sort()).toEqual(["a", "leaf"]);
+  });
+});
+
+describe("unarchiveTask — event emission (upward repair)", () => {
+  it("emits UNARCHIVED on the target and each repaired ancestor (causedBy = target)", async () => {
+    // root(archived) -> a(archived) -> leaf(archived); unarchive the leaf.
+    const at = new Date("2026-01-02");
+    db.task.findUnique.mockResolvedValue(
+      target({ id: "leaf", parentId: "a", archivedAt: at }),
+    );
+    ancestors([
+      row("a", "root", { archivedAt: at }),
+      row("root", null, { archivedAt: at }),
+    ]);
+
+    const result = await unarchiveTask({ taskId: "leaf", userId: USER });
+
+    expect(result.success).toBe(true);
+    const events = emitted();
+    expect(events.map((e) => e.taskId).sort()).toEqual(["a", "leaf", "root"]);
+    expect(events.every((e) => e.eventType === "UNARCHIVED")).toBe(true);
+
+    const byTask = Object.fromEntries(events.map((e) => [e.taskId, e]));
+    expect(byTask.leaf.payload).not.toHaveProperty("causedBy");
+    expect(byTask.a.payload).toMatchObject({ causedBy: "leaf" });
+    expect(byTask.root.payload).toMatchObject({ causedBy: "leaf" });
+  });
+
+  it("stops the upward repair at the first unarchived ancestor", async () => {
+    // root(not archived) -> a(archived) -> leaf(archived); repair stops below root.
+    const at = new Date("2026-01-02");
+    db.task.findUnique.mockResolvedValue(
+      target({ id: "leaf", parentId: "a", archivedAt: at }),
+    );
+    ancestors([
+      row("a", "root", { archivedAt: at }),
+      row("root", null), // not archived → not repaired, no event
+    ]);
+
+    const result = await unarchiveTask({ taskId: "leaf", userId: USER });
+
+    expect(result.success).toBe(true);
+    expect(emitted().map((e) => e.taskId).sort()).toEqual(["a", "leaf"]);
+  });
+});
+
+describe("hierarchy transition — rollback on emit failure", () => {
+  it("propagates an emit failure out of the transaction (no swallowed success)", async () => {
+    // The emit rides the caller's tx, so a failing insert must abort the whole
+    // operation — the wiring that lets Prisma roll the state change back. (The
+    // actual atomic DB revert is Prisma's and is exercised end-to-end in verify.)
+    db.task.findUnique.mockResolvedValue(target());
+    tree([row("root", null), row("a", "root")]);
+    mockTx.taskEvent.create.mockRejectedValue(new Error("event insert failed"));
+
+    const result = await completeTask({ taskId: "root", userId: USER });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.code).toBe("INTERNAL_SERVER_ERROR");
+    }
+  });
+});
+
+describe("restoreDeletedTask — event emission (upward repair)", () => {
+  it("emits RESTORED on the target and each repaired ancestor (causedBy = target)", async () => {
+    // root(deleted) -> a(deleted) -> leaf(deleted); restore the leaf.
+    const at = new Date("2026-01-02");
+    db.task.findUnique.mockResolvedValue(
+      target({ id: "leaf", parentId: "a", deletedAt: at }),
+    );
+    ancestors([
+      row("a", "root", { deletedAt: at }),
+      row("root", null, { deletedAt: at }),
+    ]);
+
+    const result = await restoreDeletedTask({ taskId: "leaf", userId: USER });
+
+    expect(result.success).toBe(true);
+    const events = emitted();
+    expect(events.map((e) => e.taskId).sort()).toEqual(["a", "leaf", "root"]);
+    expect(events.every((e) => e.eventType === "RESTORED")).toBe(true);
+
+    const byTask = Object.fromEntries(events.map((e) => [e.taskId, e]));
+    expect(byTask.leaf.payload).not.toHaveProperty("causedBy");
+    expect(byTask.a.payload).toMatchObject({ causedBy: "leaf" });
+    expect(byTask.root.payload).toMatchObject({ causedBy: "leaf" });
+  });
+
+  it("stops the upward repair at the first non-deleted ancestor", async () => {
+    // root(not deleted) -> a(deleted) -> leaf(deleted); repair stops below root.
+    const at = new Date("2026-01-02");
+    db.task.findUnique.mockResolvedValue(
+      target({ id: "leaf", parentId: "a", deletedAt: at }),
+    );
+    ancestors([
+      row("a", "root", { deletedAt: at }),
+      row("root", null), // not deleted → not repaired, no event
+    ]);
+
+    const result = await restoreDeletedTask({ taskId: "leaf", userId: USER });
+
+    expect(result.success).toBe(true);
+    expect(emitted().map((e) => e.taskId).sort()).toEqual(["a", "leaf"]);
+  });
+});

--- a/tests/unit/services/timeEntry.service.test.ts
+++ b/tests/unit/services/timeEntry.service.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TaskEventType } from "@prisma/client";
 import {
   createMockPrismaClient,
+  mockTx,
   type MockPrismaClient,
+  type MockTx,
 } from "@/tests/helpers/prisma-mock";
 import { buildTask, buildTimeEntry } from "@/tests/helpers/factories";
 
@@ -19,6 +22,7 @@ import {
 import prisma from "@/lib/prisma";
 
 const db = prisma as unknown as MockPrismaClient;
+const tx = mockTx as MockTx;
 
 // ─── getTimeEntriesForTask ─────────────────────────────────────────────────────
 
@@ -179,8 +183,10 @@ describe("createManualTimeEntry", () => {
     db.task.findUnique.mockResolvedValue(
       buildTask({ createdById: "test-user-1" }),
     );
+    // Runs inside a $transaction since #55, so the create rides the tx client.
+    db.$transaction.mockImplementation((fn) => fn(tx));
     const created = buildTimeEntry({ duration: 3600 });
-    db.timeEntry.create.mockResolvedValue(created);
+    tx.timeEntry.create.mockResolvedValue(created);
 
     const result = await createManualTimeEntry({
       userId: "test-user-1",
@@ -193,7 +199,7 @@ describe("createManualTimeEntry", () => {
     if (result.success) {
       expect(result.data).toEqual(created);
     }
-    expect(db.timeEntry.create).toHaveBeenCalledWith({
+    expect(tx.timeEntry.create).toHaveBeenCalledWith({
       data: {
         task: { connect: { id: "test-task-1" } },
         user: { connect: { id: "test-user-1" } },
@@ -218,6 +224,90 @@ describe("createManualTimeEntry", () => {
       where: { id: "test-task-1", deletedAt: null },
       select: { createdById: true },
     });
+  });
+});
+
+// ─── createManualTimeEntry — STARTED event ───────────────────────────────────────
+
+describe("createManualTimeEntry — STARTED event", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db.$transaction.mockImplementation((fn) => fn(tx));
+    db.task.findUnique.mockResolvedValue(
+      buildTask({ createdById: "test-user-1" }),
+    );
+    tx.timeEntry.create.mockResolvedValue(buildTimeEntry());
+  });
+
+  it("emits STARTED with the entry's start time when the task has no prior STARTED", async () => {
+    tx.taskEvent.findFirst.mockResolvedValue(null);
+
+    await createManualTimeEntry({
+      userId: "test-user-1",
+      taskId: "test-task-1",
+      startedAt: new Date("2026-01-01T10:00:00Z"),
+      stoppedAt: new Date("2026-01-01T11:00:00Z"),
+    });
+
+    expect(tx.taskEvent.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          taskId: "test-task-1",
+          userId: "test-user-1",
+          eventType: TaskEventType.STARTED,
+          payload: { startedAt: "2026-01-01T10:00:00.000Z" },
+        }),
+      }),
+    );
+  });
+
+  it("does not re-emit STARTED for a backdated entry when one already exists", async () => {
+    // Task already started (via timer or an earlier entry); a later, backdated
+    // manual entry must not move or duplicate STARTED (#23: corrections live in state).
+    tx.taskEvent.findFirst.mockResolvedValue({ id: "existing-started" });
+
+    await createManualTimeEntry({
+      userId: "test-user-1",
+      taskId: "test-task-1",
+      startedAt: new Date("2025-12-01T08:00:00Z"), // backdated before the existing STARTED
+      stoppedAt: new Date("2025-12-01T09:00:00Z"),
+    });
+
+    expect(tx.taskEvent.create).not.toHaveBeenCalled();
+  });
+
+  it("scopes the prior-STARTED guard to this task and event type", async () => {
+    tx.taskEvent.findFirst.mockResolvedValue(null);
+
+    await createManualTimeEntry({
+      userId: "test-user-1",
+      taskId: "test-task-1",
+      startedAt: new Date("2026-01-01T10:00:00Z"),
+      stoppedAt: new Date("2026-01-01T11:00:00Z"),
+    });
+
+    expect(tx.taskEvent.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          taskId: "test-task-1",
+          eventType: TaskEventType.STARTED,
+        }),
+      }),
+    );
+  });
+
+  it("fails the action (rolls back) when the STARTED emit throws", async () => {
+    tx.taskEvent.findFirst.mockResolvedValue(null);
+    tx.taskEvent.create.mockRejectedValue(new Error("emit failed"));
+
+    const result = await createManualTimeEntry({
+      userId: "test-user-1",
+      taskId: "test-task-1",
+      startedAt: new Date("2026-01-01T10:00:00Z"),
+      stoppedAt: new Date("2026-01-01T11:00:00Z"),
+    });
+
+    expect(result.success).toBe(false);
   });
 });
 


### PR DESCRIPTION
One reviewed merge for the whole parallel wave. This branch merges the four open PR branches (order: #55 → #52 → #51 → #54) on top of `main-vibe` (which already carries #50/PR #58 and #53/PR #65), with all cross-PR conflicts resolved and validated.

**Merging this PR automatically marks #66, #67, #68, #69 as merged** — their branch tips are ancestors of this branch. Coordinator closes issues #51–#55 and #23 afterwards.

## Validation
- `tsc --noEmit` clean
- Full suite: **9 files / 192 tests green** (149 baseline + 43 new across the wave)
- #54 additionally verified end-to-end against the real running app + DB (details in PR #69)

## Cross-PR integration decisions (the parts in no single PR)
- `createTask`: one transaction emits `CREATED` (the task) then `SUBTASK_CREATED` (direct parent) — #51 + #52
- `updateTask`: one transaction snapshots estimate + tag set up front, then emits `ESTIMATE_CHANGED` and `TAGS_CHANGED`, each behind its own real-change guard — #51 + #53
- `deleteTask`: `DELETED` transition events (#54) then `SUBTASK_REMOVED` on the former parent (#52), same tx
- #51's "CREATED emits exactly one event" assertion adapted to the type-filtered idiom (`SUBTASK_CREATED` now rides the same path); duplicate describe names disambiguated
- `CONTEXT.md` Current state: TaskEvent emission moved Modeled → Implemented (both review agents flagged the staleness)

## Needs your nod (flagged in #69's notes)
- Upward repairs (uncomplete/unarchive/restore) stamp repaired **ancestors** with `causedBy` too — ticket letter said "descendants"; ADR-0020 was read as one rule: every non-target task changed by the act gets `causedBy`.

## Follow-ups (filed as needs-triage after merge)
- Estimate **clear** not expressible: `UpdateTaskSchema.estimate` is optional, not nullable — `{old, new: null}` is supported by the event schema but can never fire (#68 note)
- Fold `startedEvent.ts` helper into `event.service.ts` (#66 note; file was frozen during parallel work)
- Single-source the six-verb `TransitionEventType` union from `event.service.ts` (#69 note)

🤖 Generated with [Claude Code](https://claude.com/claude-code)