### PR TITLE
fix: block starting a timer on an archived task (#56)

### DIFF
--- a/lib/services/activeTask.service.ts
+++ b/lib/services/activeTask.service.ts
@@ -49,13 +49,20 @@ export function startActiveTimer({
     // TODO: Replace with project membership/role check when collaboration is implemented
     const task = await client.task.findUnique({
       where: { id: taskId, deletedAt: null },
-      select: { createdById: true },
+      select: { createdById: true, archivedAt: true },
     });
     if (!task) return createServiceErrorResponse("NOT_FOUND", "Task not found");
     if (task.createdById !== userId)
       return createServiceErrorResponse(
         "AUTHORIZATION_ERROR",
         "User does not have access to this task",
+      );
+    // Archive is frozen state: an archived subtree must hold no running timer
+    // (the reverse direction of archiveTask's running-descendant-timer block).
+    if (task.archivedAt)
+      return createServiceErrorResponse(
+        "VALIDATION_ERROR",
+        "Cannot start a timer on an archived task",
       );
 
     const result = await client.$transaction(async (tx) => {

--- a/tests/unit/services/activeTask.service.test.ts
+++ b/tests/unit/services/activeTask.service.test.ts
@@ -104,6 +104,39 @@ describe("startActiveTimer", () => {
     }
   });
 
+  it("returns VALIDATION_ERROR when the task is archived", async () => {
+    db.task.findUnique.mockResolvedValue(
+      buildTask({ createdById: "test-user-1", archivedAt: new Date() }),
+    );
+
+    const result = await startActiveTimer({
+      userId: "test-user-1",
+      taskId: "test-task-1",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.code).toBe("VALIDATION_ERROR");
+    }
+    expect(db.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("checks ownership before the archived state (archived is not leaked to non-owners)", async () => {
+    db.task.findUnique.mockResolvedValue(
+      buildTask({ createdById: "other-user", archivedAt: new Date() }),
+    );
+
+    const result = await startActiveTimer({
+      userId: "test-user-1",
+      taskId: "test-task-1",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.code).toBe("AUTHORIZATION_ERROR");
+    }
+  });
+
   it("creates ActiveTimer when no existing timer exists", async () => {
     db.task.findUnique.mockResolvedValue(
       buildTask({ createdById: "test-user-1" }),


### PR DESCRIPTION
Closes #56.

startActiveTimer rejects archived tasks with a distinct VALIDATION_ERROR, checked after the ownership check (archived state is not leaked to non-owners). Distinct error instead of an archivedAt where-filter on purpose — #57 drops NOT_FOUND masking, and the forward transitions in task.service.ts already use VALIDATION_ERROR for timer/archive conflicts.

Test-first: red test, then fix; 194/194 green, typecheck clean.

Review notes (two-axis, sub-agent): no findings. Other timer entry points verified closed (changeActiveTimerStart cannot retarget a task; stop only removes). Out-of-scope observation: timeEntry.service.ts still allows placing completed time entries on archived tasks — possible follow-up ticket.

Restores the invariant applyTransition (#57/#62) relies on: an archived subtree holds no running timer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)