### PR TITLE
Prefactor: move hierarchy policy to the domain layer (#59)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -75,9 +75,9 @@ Derived from datetime flags, no enum (ADR-0007): `completedAt`, `archivedAt`, `d
 
 - **Stack**: Next.js 16 App Router, React 19, Prisma 7, MySQL 8 (Docker), NextAuth 5 (credentials-only), Tailwind 4, Zod, pnpm.
 - **Route boundary**: authenticated app under `app/s/`, public pages under `app/public/`; session middleware in `proxy.ts`.
-- **Three layers**: Component → Server Action (`lib/actions/`) → Service (`lib/services/`) → Prisma. Business logic in services only. Reads: server components call services directly. API routes only for external integrations.
+- **Three layers**: Component → Server Action (`lib/actions/`) → Service (`lib/services/`) → Prisma. Business logic in services only — except pure domain policy, which lives in `lib/domain/` (no prisma, no server-only imports, client-importable; #59). `lib/services/` is server-only (guarded via `import "server-only"` in `serviceUtil.ts`). Reads: server components call services directly. API routes only for external integrations.
 - **Security boundary (ADR-0017 → ADR-0019)**: actions + server components authenticate via `auth()`. Ownership checks today: 19 scattered sites inside services. Decided target: central `lib/authz/policy.ts`, pure `can()`/`assertCan()`, `NOT_FOUND`-masked errors — **deliberately deferred until multiplayer** (#22; plan: `docs/AUTHORIZATION_PLAN.md`).
-- **Hierarchy transitions (ADR-0018)**: complete/uncomplete/archive/unarchive/delete/restore all flow through `lib/services/taskHierarchyPolicy.ts` — `validateTransition()` → `buildTransitionPlan()` → execute. Never inline hierarchy validation in service functions. Per-operation rules table: the ADR.
+- **Hierarchy transitions (ADR-0018)**: complete/uncomplete/archive/unarchive/delete/restore all flow through `lib/domain/taskHierarchyPolicy.ts` — `validateTransition()` → `buildTransitionPlan()` → execute. Never inline hierarchy validation in service functions. Per-operation rules table: the ADR.
 - **Toggl isolation**: all Toggl code in `lib/toggl/`; per-user tokens in User model, never env vars; app fully functional without Toggl.
 
 ## Invariants (verify after changes)

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -102,7 +102,9 @@ issue-tracker/
 │   │   ├── task.ts                   # CreateTaskSchema, UpdateTaskSchema, TaskStatus, TaskNode type
 │   │   ├── project.ts               # Project schemas
 │   │   └── timeEntry.ts             # Time entry schemas (placeholder)
-│   ├── services/                     # Business logic (pure functions, Prisma calls)
+│   ├── domain/                       # Pure domain logic, client-importable (no prisma, no server-only)
+│   │   └── taskHierarchyPolicy.ts    # Hierarchy transition validation + plan building (ADR-0018)
+│   ├── services/                     # Business logic (pure functions, Prisma calls) — server-only
 │   │   ├── project.service.ts        # Project reads
 │   │   ├── task.service.ts           # Task CRUD (create, update, hasActiveTimers)
 │   │   ├── timeEntry.service.ts      # Historical time entry queries (future)

--- a/docs/adr/0018-policy-based-hierarchy-transitions.md
+++ b/docs/adr/0018-policy-based-hierarchy-transitions.md
@@ -2,7 +2,7 @@
 
 **Context:** Task hierarchy operations (complete, uncomplete, archive, unarchive, delete, restore) each have different rules about which ancestor states are forbidden and how state changes propagate up/down the tree. Inline validation logic was duplicated across service functions.
 
-**Decision:** Extract validation and plan-building into `lib/services/taskHierarchyPolicy.ts`. Each operation is a `TransitionKind`. `validateTransition()` checks ancestor legality; `buildTransitionPlan()` returns a `TransitionPlan` with IDs and values for `completedAt`, `archivedAt`, `deletedAt`. Service functions call validate → build plan → execute plan.
+**Decision:** Extract validation and plan-building into `lib/services/taskHierarchyPolicy.ts` (moved to `lib/domain/taskHierarchyPolicy.ts` in #59 — pure domain logic, client-importable, owns its own error type). Each operation is a `TransitionKind`. `validateTransition()` checks ancestor legality; `buildTransitionPlan()` returns a `TransitionPlan` with IDs and values for `completedAt`, `archivedAt`, `deletedAt`. Service functions call validate → build plan → execute plan.
 
 **Rules per operation:**
 | Operation | Self forbidden states | Downward cascade | Ancestor forbidden states | Ancestor propagation |

--- a/lib/domain/taskHierarchyPolicy.ts
+++ b/lib/domain/taskHierarchyPolicy.ts
@@ -1,5 +1,3 @@
-import { ServiceErrorResponse } from "./serviceUtil";
-
 // ─── Types ─────────────────────────────────────────────────────────────────────
 
 export type TransitionKind =
@@ -32,11 +30,17 @@ const EMPTY_PLAN: TransitionPlan = {
 
 // ─── Validation ────────────────────────────────────────────────────────────────
 
-type ValidationError = {
-  code: ServiceErrorResponse["error"]["code"];
+/**
+ * The policy's own error type — deliberately not the service error shape, so
+ * this domain module stays importable from client code (#57, #59). Splitting
+ * a dedicated TRANSITION_INVALID code out of UNEXPECTED_ERROR is #14.
+ */
+export type TransitionErrorCode = "UNEXPECTED_ERROR";
+export type ValidationError = {
+  code: TransitionErrorCode;
   message: string;
 };
-type ValidationResult =
+export type ValidationResult =
   | { valid: true }
   | { valid: false; error: ValidationError };
 

--- a/lib/services/serviceUtil.ts
+++ b/lib/services/serviceUtil.ts
@@ -1,3 +1,8 @@
+// Guard: fail the build if client code ever imports service utilities (and
+// with them prisma) — domain logic importable from the client lives in
+// lib/domain/ instead (#59).
+import "server-only";
+
 import { Prisma } from "@prisma/client";
 import { z } from "zod";
 

--- a/lib/services/task.service.ts
+++ b/lib/services/task.service.ts
@@ -12,7 +12,7 @@ import {
   buildTransitionPlan,
   type LineageNode,
   type TransitionPlan,
-} from "./taskHierarchyPolicy";
+} from "../domain/taskHierarchyPolicy";
 
 // ─── Shared Helpers ────────────────────────────────────────────────────────────
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-router-dom": "^7.13.0",
+    "server-only": "^0.0.1",
     "vitest": "^4.0.18",
     "zod": "^4.3.6"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,9 @@ importers:
       react-router-dom:
         specifier: ^7.13.0
         version: 7.13.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      server-only:
+        specifier: ^0.0.1
+        version: 0.0.1
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)
@@ -5257,6 +5260,12 @@ packages:
         integrity: sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==,
       }
 
+  server-only@0.0.1:
+    resolution:
+      {
+        integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==,
+      }
+
   set-cookie-parser@2.7.2:
     resolution:
       {
@@ -9244,6 +9253,8 @@ snapshots:
   semver@7.7.4: {}
 
   seq-queue@0.0.5: {}
+
+  server-only@0.0.1: {}
 
   set-cookie-parser@2.7.2: {}
 

--- a/tests/stubs/server-only.ts
+++ b/tests/stubs/server-only.ts
@@ -1,0 +1,3 @@
+// The real "server-only" package throws on import outside a React server
+// context. Tests run in plain node, so vitest.config.ts aliases it here.
+export {};

--- a/tests/unit/domain/taskHierarchyPolicy.test.ts
+++ b/tests/unit/domain/taskHierarchyPolicy.test.ts
@@ -3,7 +3,7 @@ import {
   validateTransition,
   buildTransitionPlan,
   type LineageNode,
-} from "@/lib/services/taskHierarchyPolicy";
+} from "@/lib/domain/taskHierarchyPolicy";
 
 // ─── Helpers ───────────────────────────────────────────────────────────────────
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       include: [
+        "lib/domain/**",
         "lib/services/**",
         "lib/schema/**",
         "lib/util.ts",
@@ -20,6 +21,7 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(__dirname),
+      "server-only": path.resolve(__dirname, "tests/stubs/server-only.ts"),
     },
   },
 });


### PR DESCRIPTION
Closes #59 (part of #57).

## What

- `taskHierarchyPolicy.ts` moved `lib/services/` → `lib/domain/` (new folder: pure, client-importable domain logic). Zero imports left in the module.
- Policy owns its error type (`TransitionErrorCode`) — no more `ServiceErrorResponse` borrow from serviceUtil. Kept as `"UNEXPECTED_ERROR"` so behavior is identical; the TRANSITION_INVALID split stays #14.
- `import "server-only"` guard in `serviceUtil.ts`: client code can never pull services (and prisma) into its bundle. New tiny dep `server-only`; vitest aliases it to a stub since tests run in plain node.
- Test file mirrored to `tests/unit/domain/`; coverage now includes `lib/domain/**`.
- Docs follow the move: CONTEXT.md (layer rule + policy path), ADR-0018 (path note), DEVELOPER.md (tree).

## Verify

- `tsc --noEmit` clean, `next build` succeeds, 194/194 tests pass (unchanged apart from the moved import path).
- Reviewed via /code-review (Standards + Spec): spec axis clean; standards axis flagged stale doc paths — fixed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)