### PR TITLE
TransitionPlan: turn the plan into a list of writes (#60)

### DIFF
--- a/lib/domain/taskHierarchyPolicy.ts
+++ b/lib/domain/taskHierarchyPolicy.ts
@@ -16,17 +16,38 @@ export type LineageNode = {
   deletedAt: Date | null;
 };
 
-export type TransitionPlan = {
-  setCompletedAt: { ids: string[]; value: Date | null };
-  setArchivedAt: { ids: string[]; value: Date | null };
-  setDeletedAt: { ids: string[]; value: Date | null };
+/** The three date columns a hierarchy transition can write. */
+export type TransitionState = "completedAt" | "archivedAt" | "deletedAt";
+
+/** Set `state` to `value` on every task in `ids`. */
+export type PlanWrite = {
+  state: TransitionState;
+  ids: string[];
+  value: Date | null;
 };
 
-const EMPTY_PLAN: TransitionPlan = {
-  setCompletedAt: { ids: [], value: null },
-  setArchivedAt: { ids: [], value: null },
-  setDeletedAt: { ids: [], value: null },
+/**
+ * Everything a transition changes, as a flat list the executor replays in
+ * order — it needs no knowledge of the kind that produced it (#57, #60).
+ *
+ * A plan lists only what it actually writes: a kind with nothing to do plans
+ * no writes at all. The same state may appear more than once with different
+ * values, which is how #63 backdates some ids while clearing others.
+ */
+export type TransitionPlan = {
+  writes: PlanWrite[];
 };
+
+const EMPTY_PLAN: TransitionPlan = { writes: [] };
+
+/** A plan of one write, dropped entirely when it would touch no task. */
+function planWrite(
+  state: TransitionState,
+  ids: string[],
+  value: Date | null,
+): TransitionPlan {
+  return ids.length > 0 ? { writes: [{ state, ids, value }] } : EMPTY_PLAN;
+}
 
 // ─── Validation ────────────────────────────────────────────────────────────────
 
@@ -252,6 +273,27 @@ function pruneCascade(
 }
 
 /**
+ * The task plus the unbroken run of ancestors already in the same state,
+ * nearest parent outward. A backward transition clears exactly this run: it
+ * stops at the first ancestor not in the state, so an ancestor sitting beyond
+ * a gap is left alone. Whether such a gap is legal at all is validation's
+ * business, not the plan's.
+ */
+function ownStateRun(
+  task: LineageNode,
+  ancestors: LineageNode[],
+  inState: (n: LineageNode) => boolean,
+): string[] {
+  const ids: string[] = [];
+  if (inState(task)) ids.push(task.id);
+  for (const a of ancestors) {
+    if (!inState(a)) break;
+    ids.push(a.id);
+  }
+  return ids;
+}
+
+/**
  * Build the set of mutations required for a hierarchy transition.
  *
  * `task` is the target. `ancestors` ordered nearest-parent → root.
@@ -284,94 +326,46 @@ function buildCompletePlan(
   task: LineageNode,
   descendants: LineageNode[],
 ): TransitionPlan {
-  return {
-    ...EMPTY_PLAN,
-    setCompletedAt: {
-      ids: pruneCascade(task.id, descendants, (n) => !!n.completedAt),
-      value: new Date(),
-    },
-  };
+  const ids = pruneCascade(task.id, descendants, (n) => !!n.completedAt);
+  return planWrite("completedAt", ids, new Date());
 }
 
 function buildUncompletePlan(
   task: LineageNode,
   ancestors: LineageNode[],
 ): TransitionPlan {
-  const ids: string[] = [];
-  if (task.completedAt) ids.push(task.id);
-  for (const a of ancestors) {
-    if (a.completedAt) {
-      ids.push(a.id);
-    } else {
-      break; // stop at first uncompleted ancestor (contiguous prefix)
-    }
-  }
-  return {
-    ...EMPTY_PLAN,
-    setCompletedAt: { ids, value: null },
-  };
+  const ids = ownStateRun(task, ancestors, (n) => !!n.completedAt);
+  return planWrite("completedAt", ids, null);
 }
 
 function buildArchivePlan(
   task: LineageNode,
   descendants: LineageNode[],
 ): TransitionPlan {
-  return {
-    ...EMPTY_PLAN,
-    setArchivedAt: {
-      ids: pruneCascade(task.id, descendants, (n) => !!n.archivedAt),
-      value: new Date(),
-    },
-  };
+  const ids = pruneCascade(task.id, descendants, (n) => !!n.archivedAt);
+  return planWrite("archivedAt", ids, new Date());
 }
 
 function buildUnarchivePlan(
   task: LineageNode,
   ancestors: LineageNode[],
 ): TransitionPlan {
-  const ids: string[] = [];
-  if (task.archivedAt) ids.push(task.id);
-  for (const a of ancestors) {
-    if (a.archivedAt) {
-      ids.push(a.id);
-    } else {
-      break; // stop at first unarchived ancestor (contiguous prefix)
-    }
-  }
-  return {
-    ...EMPTY_PLAN,
-    setArchivedAt: { ids, value: null },
-  };
+  const ids = ownStateRun(task, ancestors, (n) => !!n.archivedAt);
+  return planWrite("archivedAt", ids, null);
 }
 
 function buildDeletePlan(
   task: LineageNode,
   descendants: LineageNode[],
 ): TransitionPlan {
-  return {
-    ...EMPTY_PLAN,
-    setDeletedAt: {
-      ids: pruneCascade(task.id, descendants, (n) => !!n.deletedAt),
-      value: new Date(),
-    },
-  };
+  const ids = pruneCascade(task.id, descendants, (n) => !!n.deletedAt);
+  return planWrite("deletedAt", ids, new Date());
 }
 
 function buildUndeletePlan(
   task: LineageNode,
   ancestors: LineageNode[],
 ): TransitionPlan {
-  const ids: string[] = [];
-  if (task.deletedAt) ids.push(task.id);
-  for (const a of ancestors) {
-    if (a.deletedAt) {
-      ids.push(a.id);
-    } else {
-      break; // stop at first non-deleted ancestor (repair contiguous gap only)
-    }
-  }
-  return {
-    ...EMPTY_PLAN,
-    setDeletedAt: { ids, value: null },
-  };
+  const ids = ownStateRun(task, ancestors, (n) => !!n.deletedAt);
+  return planWrite("deletedAt", ids, null);
 }

--- a/lib/services/task.service.ts
+++ b/lib/services/task.service.ts
@@ -12,6 +12,7 @@ import {
   buildTransitionPlan,
   type LineageNode,
   type TransitionPlan,
+  type TransitionState,
 } from "../domain/taskHierarchyPolicy";
 
 // ─── Shared Helpers ────────────────────────────────────────────────────────────
@@ -75,25 +76,31 @@ async function collectDescendantNodes(
   return nodes;
 }
 
+/**
+ * Replay a plan's writes in order. The plan already decided which tasks change
+ * and to what, so this stays a loop with no per-kind knowledge (#60).
+ */
 async function executePlan(plan: TransitionPlan, tx: DbClient): Promise<void> {
-  if (plan.setCompletedAt.ids.length > 0) {
+  for (const write of plan.writes) {
     await tx.task.updateMany({
-      where: { id: { in: plan.setCompletedAt.ids } },
-      data: { completedAt: plan.setCompletedAt.value },
+      where: { id: { in: write.ids } },
+      data: { [write.state]: write.value },
     });
   }
-  if (plan.setArchivedAt.ids.length > 0) {
-    await tx.task.updateMany({
-      where: { id: { in: plan.setArchivedAt.ids } },
-      data: { archivedAt: plan.setArchivedAt.value },
-    });
-  }
-  if (plan.setDeletedAt.ids.length > 0) {
-    await tx.task.updateMany({
-      where: { id: { in: plan.setDeletedAt.ids } },
-      data: { deletedAt: plan.setDeletedAt.value },
-    });
-  }
+}
+
+/**
+ * What the plan does to one state: the ids it writes and the value it stores.
+ * Every plan today writes a given state at most once, so callers reporting a
+ * count or emitting one event per changed task read it through here rather
+ * than indexing into the write list. #62 moves event planning into the policy
+ * and removes these lookups.
+ */
+function writeFor(
+  plan: TransitionPlan,
+  state: TransitionState,
+): { ids: string[]; value: Date | null } {
+  return plan.writes.find((w) => w.state === state) ?? { ids: [], value: null };
 }
 
 /**
@@ -456,7 +463,7 @@ export function deleteTask({
         type: TaskEventType.DELETED,
         userId,
         targetTaskId: task.id,
-        changed: plan.setDeletedAt,
+        changed: writeFor(plan, "deletedAt"),
       });
 
       // Record the removal on the former direct parent's trail (#52). Only the
@@ -473,7 +480,7 @@ export function deleteTask({
 
       return createSuccessResponseWithData({
         id: taskId,
-        deletedCount: plan.setDeletedAt.ids.length,
+        deletedCount: writeFor(plan, "deletedAt").ids.length,
       });
     });
   }, "Failed to delete task");
@@ -564,12 +571,12 @@ export function completeTask({
         type: TaskEventType.COMPLETED,
         userId,
         targetTaskId: task.id,
-        changed: plan.setCompletedAt,
+        changed: writeFor(plan, "completedAt"),
       });
 
       return createSuccessResponseWithData({
         id: taskId,
-        completedCount: plan.setCompletedAt.ids.length,
+        completedCount: writeFor(plan, "completedAt").ids.length,
       });
     });
   }, "Failed to complete task");
@@ -624,12 +631,12 @@ export function uncompleteTask({
         type: TaskEventType.UNCOMPLETED,
         userId,
         targetTaskId: task.id,
-        changed: plan.setCompletedAt,
+        changed: writeFor(plan, "completedAt"),
       });
 
       return createSuccessResponseWithData({
         id: taskId,
-        uncompletedCount: plan.setCompletedAt.ids.length,
+        uncompletedCount: writeFor(plan, "completedAt").ids.length,
       });
     });
   }, "Failed to uncomplete task");
@@ -705,12 +712,12 @@ export function archiveTask({
         type: TaskEventType.ARCHIVED,
         userId,
         targetTaskId: task.id,
-        changed: plan.setArchivedAt,
+        changed: writeFor(plan, "archivedAt"),
       });
 
       return createSuccessResponseWithData({
         id: taskId,
-        archivedCount: plan.setArchivedAt.ids.length,
+        archivedCount: writeFor(plan, "archivedAt").ids.length,
       });
     });
   }, "Failed to archive task");
@@ -762,7 +769,7 @@ export function unarchiveTask({
         type: TaskEventType.UNARCHIVED,
         userId,
         targetTaskId: task.id,
-        changed: plan.setArchivedAt,
+        changed: writeFor(plan, "archivedAt"),
       });
 
       return createSuccessResponseWithData({ id: taskId });
@@ -816,12 +823,12 @@ export function restoreDeletedTask({
         type: TaskEventType.RESTORED,
         userId,
         targetTaskId: task.id,
-        changed: plan.setDeletedAt,
+        changed: writeFor(plan, "deletedAt"),
       });
 
       return createSuccessResponseWithData({
         id: taskId,
-        restoredCount: plan.setDeletedAt.ids.length,
+        restoredCount: writeFor(plan, "deletedAt").ids.length,
       });
     });
   }, "Failed to restore task");

--- a/tests/unit/domain/taskHierarchyPolicy.test.ts
+++ b/tests/unit/domain/taskHierarchyPolicy.test.ts
@@ -3,6 +3,8 @@ import {
   validateTransition,
   buildTransitionPlan,
   type LineageNode,
+  type TransitionPlan,
+  type TransitionState,
 } from "@/lib/domain/taskHierarchyPolicy";
 
 // ─── Helpers ───────────────────────────────────────────────────────────────────
@@ -22,6 +24,24 @@ function node(
     deletedAt: null,
     ...overrides,
   };
+}
+
+/** Every id the plan writes for one state, in plan order. */
+function ids(plan: TransitionPlan, state: TransitionState): string[] {
+  return plan.writes.filter((w) => w.state === state).flatMap((w) => w.ids);
+}
+
+/** The states the plan touches, in order — asserts nothing else is written. */
+function states(plan: TransitionPlan): TransitionState[] {
+  return plan.writes.map((w) => w.state);
+}
+
+/** The value the plan stores for one state; undefined when it does not write it. */
+function value(
+  plan: TransitionPlan,
+  state: TransitionState,
+): Date | null | undefined {
+  return plan.writes.find((w) => w.state === state)?.value;
 }
 
 // ─── validateTransition: COMPLETE ──────────────────────────────────────────────
@@ -362,10 +382,9 @@ describe("buildTransitionPlan — COMPLETE", () => {
     const task = node("t1", null);
     const descendants = [task, node("t2", "t1"), node("t3", "t2")];
     const plan = buildTransitionPlan("COMPLETE", task, [], descendants);
-    expect(plan.setCompletedAt.ids).toEqual(["t1", "t2", "t3"]);
-    expect(plan.setCompletedAt.value).toBeInstanceOf(Date);
-    expect(plan.setArchivedAt.ids).toEqual([]);
-    expect(plan.setDeletedAt.ids).toEqual([]);
+    expect(ids(plan, "completedAt")).toEqual(["t1", "t2", "t3"]);
+    expect(value(plan, "completedAt")).toBeInstanceOf(Date);
+    expect(states(plan)).toEqual(["completedAt"]);
   });
 
   it("stops at an already-completed descendant and keeps its date", () => {
@@ -377,7 +396,7 @@ describe("buildTransitionPlan — COMPLETE", () => {
       node("t4", "t2", { completedAt: now }), // below the stop — not walked
     ];
     const plan = buildTransitionPlan("COMPLETE", task, [], descendants);
-    expect(plan.setCompletedAt.ids).toEqual(["t1", "t3"]);
+    expect(ids(plan, "completedAt")).toEqual(["t1", "t3"]);
   });
 });
 
@@ -391,8 +410,8 @@ describe("buildTransitionPlan — UNCOMPLETE", () => {
       node("t1", null), // uncompleted
     ];
     const plan = buildTransitionPlan("UNCOMPLETE", task, ancestors);
-    expect(plan.setCompletedAt.ids).toEqual(["t3", "t2"]);
-    expect(plan.setCompletedAt.value).toBeNull();
+    expect(ids(plan, "completedAt")).toEqual(["t3", "t2"]);
+    expect(value(plan, "completedAt")).toBeNull();
   });
 
   it("stops at first uncompleted ancestor", () => {
@@ -403,14 +422,14 @@ describe("buildTransitionPlan — UNCOMPLETE", () => {
       node("t1", null, { completedAt: now }), // should NOT be included (gap already validated)
     ];
     const plan = buildTransitionPlan("UNCOMPLETE", task, ancestors);
-    expect(plan.setCompletedAt.ids).toEqual(["t4", "t3"]);
+    expect(ids(plan, "completedAt")).toEqual(["t4", "t3"]);
   });
 
-  it("returns empty ids when task and ancestors are already uncompleted", () => {
+  it("plans no writes when task and ancestors are already uncompleted", () => {
     const task = node("t2", "t1");
     const ancestors = [node("t1", null)];
     const plan = buildTransitionPlan("UNCOMPLETE", task, ancestors);
-    expect(plan.setCompletedAt.ids).toEqual([]);
+    expect(plan.writes).toEqual([]);
   });
 });
 
@@ -421,8 +440,9 @@ describe("buildTransitionPlan — ARCHIVE", () => {
     const task = node("t1", null);
     const descendants = [task, node("t2", "t1")];
     const plan = buildTransitionPlan("ARCHIVE", task, [], descendants);
-    expect(plan.setArchivedAt.ids).toEqual(["t1", "t2"]);
-    expect(plan.setArchivedAt.value).toBeInstanceOf(Date);
+    expect(ids(plan, "archivedAt")).toEqual(["t1", "t2"]);
+    expect(value(plan, "archivedAt")).toBeInstanceOf(Date);
+    expect(states(plan)).toEqual(["archivedAt"]);
   });
 
   it("stops at an already-archived descendant and keeps its date", () => {
@@ -434,7 +454,7 @@ describe("buildTransitionPlan — ARCHIVE", () => {
       node("t4", "t2", { archivedAt: now }), // below the stop — not walked
     ];
     const plan = buildTransitionPlan("ARCHIVE", task, [], descendants);
-    expect(plan.setArchivedAt.ids).toEqual(["t1", "t3"]);
+    expect(ids(plan, "archivedAt")).toEqual(["t1", "t3"]);
   });
 });
 
@@ -448,8 +468,8 @@ describe("buildTransitionPlan — UNARCHIVE", () => {
       node("t1", null), // unarchived — stop
     ];
     const plan = buildTransitionPlan("UNARCHIVE", task, ancestors);
-    expect(plan.setArchivedAt.ids).toEqual(["t3", "t2"]);
-    expect(plan.setArchivedAt.value).toBeNull();
+    expect(ids(plan, "archivedAt")).toEqual(["t3", "t2"]);
+    expect(value(plan, "archivedAt")).toBeNull();
   });
 
   it("stops at first unarchived ancestor", () => {
@@ -459,14 +479,14 @@ describe("buildTransitionPlan — UNARCHIVE", () => {
       node("t1", null, { archivedAt: now }), // should NOT be included
     ];
     const plan = buildTransitionPlan("UNARCHIVE", task, ancestors);
-    expect(plan.setArchivedAt.ids).toEqual(["t3"]);
+    expect(ids(plan, "archivedAt")).toEqual(["t3"]);
   });
 
-  it("returns empty ids when task and ancestors are already unarchived", () => {
+  it("plans no writes when task and ancestors are already unarchived", () => {
     const task = node("t2", "t1");
     const ancestors = [node("t1", null)];
     const plan = buildTransitionPlan("UNARCHIVE", task, ancestors);
-    expect(plan.setArchivedAt.ids).toEqual([]);
+    expect(plan.writes).toEqual([]);
   });
 });
 
@@ -481,8 +501,9 @@ describe("buildTransitionPlan — DELETE", () => {
       node("t3", "t2"),
     ];
     const plan = buildTransitionPlan("DELETE", task, [], descendants);
-    expect(plan.setDeletedAt.ids).toEqual(["t1", "t2", "t3"]);
-    expect(plan.setDeletedAt.value).toBeInstanceOf(Date);
+    expect(ids(plan, "deletedAt")).toEqual(["t1", "t2", "t3"]);
+    expect(value(plan, "deletedAt")).toBeInstanceOf(Date);
+    expect(states(plan)).toEqual(["deletedAt"]);
   });
 
   it("stops at an already-deleted descendant and keeps its date", () => {
@@ -494,7 +515,7 @@ describe("buildTransitionPlan — DELETE", () => {
       node("t4", "t2", { deletedAt: now }), // below the stop — not walked
     ];
     const plan = buildTransitionPlan("DELETE", task, [], descendants);
-    expect(plan.setDeletedAt.ids).toEqual(["t1", "t3"]);
+    expect(ids(plan, "deletedAt")).toEqual(["t1", "t3"]);
   });
 });
 
@@ -508,8 +529,8 @@ describe("buildTransitionPlan — UNDELETE", () => {
       node("t1", null), // not deleted — stop
     ];
     const plan = buildTransitionPlan("UNDELETE", task, ancestors);
-    expect(plan.setDeletedAt.ids).toEqual(["t3", "t2"]);
-    expect(plan.setDeletedAt.value).toBeNull();
+    expect(ids(plan, "deletedAt")).toEqual(["t3", "t2"]);
+    expect(value(plan, "deletedAt")).toBeNull();
   });
 
   it("stops at first non-deleted ancestor", () => {
@@ -519,14 +540,14 @@ describe("buildTransitionPlan — UNDELETE", () => {
       node("t1", null, { deletedAt: now }), // should NOT be included
     ];
     const plan = buildTransitionPlan("UNDELETE", task, ancestors);
-    expect(plan.setDeletedAt.ids).toEqual(["t3"]);
+    expect(ids(plan, "deletedAt")).toEqual(["t3"]);
   });
 
   it("does not touch archivedAt", () => {
     const task = node("t2", "t1", { deletedAt: now, archivedAt: now });
     const ancestors = [node("t1", null, { deletedAt: now, archivedAt: now })];
     const plan = buildTransitionPlan("UNDELETE", task, ancestors);
-    expect(plan.setDeletedAt.ids).toEqual(["t2", "t1"]);
-    expect(plan.setArchivedAt.ids).toEqual([]);
+    expect(ids(plan, "deletedAt")).toEqual(["t2", "t1"]);
+    expect(states(plan)).toEqual(["deletedAt"]);
   });
 });


### PR DESCRIPTION
Closes #60 (part of #57).

**Stacked on #75 (#59)** — base is `feat/59-domain-policy`, not `main-vibe`. Review after #75 lands, or read only the second commit.

## What

- `TransitionPlan` was three fixed slots (`setCompletedAt` / `setArchivedAt` / `setDeletedAt`). Every kind filled one and carried two empty ones, and `executePlan` branched per slot.
- Plan is now `{ writes: [{ state, ids, value }] }` — a flat list. `executePlan` replays it in a loop with no per-kind knowledge.
- A plan lists only what it actually writes, so a kind with nothing to do plans no writes at all (`writes: []`) instead of three empty slots.
- The same state may appear more than once with different values — #63 needs that to backdate some ids while clearing others.
- The three backward builders (UNCOMPLETE/UNARCHIVE/UNDELETE) ran the same contiguous-prefix loop; pulled out as `ownStatePrefix`.

## Shape note

#57 says the plan carries writes **plus event entries**. That is why this is `{ writes: [...] }` and not a bare array — #62 adds `events` alongside without reshaping again. `writeFor()` in `task.service.ts` is a short-lived reader for the event/count call sites; #62 deletes it when event planning moves into the policy.

## Verify

- Pure refactor, no behavior change. `tsc --noEmit` clean, **194/194 tests pass** — same count as #75's baseline.
- Policy tests stay zero-mock and still go through `validateTransition` / `buildTransitionPlan` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)