### PR TITLE
applyTransition: one orchestrator for all six transitions (#62, #54)

### DIFF
--- a/lib/domain/taskHierarchyPolicy.ts
+++ b/lib/domain/taskHierarchyPolicy.ts
@@ -19,6 +19,33 @@ export type LineageNode = {
 /** The three date columns a hierarchy transition can write. */
 export type TransitionState = "completedAt" | "archivedAt" | "deletedAt";
 
+const STATES = ["completedAt", "archivedAt", "deletedAt"] as const;
+
+/**
+ * How strongly a state holds a task: **delete > archive > complete** (#57).
+ *
+ * One order runs both directions. Forward kinds cascade down through states
+ * strictly weaker than their own and stop at equal-or-stronger: the stronger
+ * state already covers everything below it, and its date is estimation
+ * evidence worth keeping (#44). Backward kinds read the same order upward,
+ * inheriting the strictly weaker states their ancestors still hold (#63).
+ *
+ * Illegal moves fall out of it too — uncompleting through an archived ancestor
+ * asks to leave a task in a state its ancestor's stronger one forbids.
+ */
+const STRENGTH: Record<TransitionState, number> = {
+  completedAt: 1,
+  archivedAt: 2,
+  deletedAt: 3,
+};
+
+/** Whether the node is held by `state` or by anything stronger than it. */
+function heldBySameOrStronger(node: LineageNode, state: TransitionState): boolean {
+  return STATES.some(
+    (s) => STRENGTH[s] >= STRENGTH[state] && node[s] !== null,
+  );
+}
+
 /** Set `state` to `value` on every task in `ids`. */
 export type PlanWrite = {
   state: TransitionState;
@@ -27,26 +54,80 @@ export type PlanWrite = {
 };
 
 /**
- * Everything a transition changes, as a flat list the executor replays in
+ * One entry for the audit ledger: this task changed, at this time, because of
+ * this transition. `causedBy` names the task the user actually acted on, and
+ * is set on every task except that target (ADR-0020).
+ *
+ * `kind` stays domain vocabulary — mapping it to a stored event type is the
+ * service's job, which is what keeps this module free of prisma (#59).
+ */
+export type PlanEvent = {
+  kind: TransitionKind;
+  taskId: string;
+  at: Date;
+  causedBy?: string;
+};
+
+/**
+ * Everything a transition changes, as flat lists the executor replays in
  * order — it needs no knowledge of the kind that produced it (#57, #60).
  *
- * A plan lists only what it actually writes: a kind with nothing to do plans
- * no writes at all. The same state may appear more than once with different
- * values, which is how #63 backdates some ids while clearing others.
+ * A plan lists only what it actually does: a kind with nothing to do plans no
+ * writes and no events. The same state may appear in more than one write with
+ * different values, which is how #63 backdates some ids while clearing others.
  */
 export type TransitionPlan = {
   writes: PlanWrite[];
+  events: PlanEvent[];
 };
 
-const EMPTY_PLAN: TransitionPlan = { writes: [] };
-
-/** A plan of one write, dropped entirely when it would touch no task. */
-function planWrite(
+/** One write, or none at all when it would touch no task. */
+function writeOne(
   state: TransitionState,
   ids: string[],
   value: Date | null,
-): TransitionPlan {
-  return ids.length > 0 ? { writes: [{ state, ids, value }] } : EMPTY_PLAN;
+): PlanWrite[] {
+  return ids.length > 0 ? [{ state, ids, value }] : [];
+}
+
+/**
+ * The state a kind is *about* — the flag it sets or clears on the target. Both
+ * directions of a pair share one state, since they move along the same axis.
+ *
+ * Only writes to this state are the transition's own act, so only they are
+ * worth an event. A write to any other state is a side effect the transition
+ * makes to keep the tree legal (#63's backdated inherits), and stays silent.
+ */
+const OWN_STATE: Record<TransitionKind, TransitionState> = {
+  COMPLETE: "completedAt",
+  UNCOMPLETE: "completedAt",
+  ARCHIVE: "archivedAt",
+  UNARCHIVE: "archivedAt",
+  DELETE: "deletedAt",
+  UNDELETE: "deletedAt",
+};
+
+/**
+ * One event per task the transition's own-state write touches.
+ *
+ * Forward kinds stamp a date and the event carries it. Backward kinds store
+ * null, so the event carries the time of the act instead — the stored fact and
+ * the audit trail are allowed to differ (#57).
+ */
+function planEvents(
+  kind: TransitionKind,
+  task: LineageNode,
+  writes: PlanWrite[],
+): PlanEvent[] {
+  const own = writes.find((w) => w.state === OWN_STATE[kind]);
+  if (!own) return [];
+  const at = own.value ?? new Date();
+  return own.ids.map((id) => ({
+    kind,
+    taskId: id,
+    at,
+    ...(id === task.id ? {} : { causedBy: task.id }),
+  }));
 }
 
 // ─── Validation ────────────────────────────────────────────────────────────────
@@ -240,16 +321,21 @@ function validateUndelete(ancestors: LineageNode[]): ValidationResult {
 // ─── Plan Building ─────────────────────────────────────────────────────────────
 
 /**
- * Downward-cascade stop rule (#44): a descendant already in the target state
- * keeps its original date — it is not re-stamped, and the walk does not
- * continue below it. The no-gaps invariant (CONTEXT.md invariant 5) means
- * everything below it is already in the target state, so nothing is missed.
- * The dates are estimation evidence; overwriting them destroys it.
+ * Downward-cascade stop rule (#44), read through the strength order.
+ *
+ * A descendant already held by `state` — or by anything stronger — keeps its
+ * original date: it is not re-stamped, and the walk does not continue below
+ * it. The no-gaps invariant (CONTEXT.md invariant 5) means everything under it
+ * is at least as strongly held, so nothing is missed. The dates are estimation
+ * evidence; overwriting them destroys it.
+ *
+ * The order does the deciding here, so the caller may hand over the whole
+ * subtree and does not have to pre-filter it into agreement (#62).
  */
 function pruneCascade(
   taskId: string,
   descendants: LineageNode[],
-  inTargetState: (n: LineageNode) => boolean,
+  state: TransitionState,
 ): string[] {
   const byId = new Map(descendants.map((n) => [n.id, n]));
   const childrenMap = new Map<string, string[]>();
@@ -265,7 +351,7 @@ function pruneCascade(
   while (queue.length > 0) {
     const current = queue.shift()!;
     const node = byId.get(current);
-    if (!node || inTargetState(node)) continue; // stop: keep its date, skip its subtree
+    if (!node || heldBySameOrStronger(node, state)) continue; // stop: keep its date, skip its subtree
     ids.push(current);
     queue.push(...(childrenMap.get(current) ?? []));
   }
@@ -282,12 +368,12 @@ function pruneCascade(
 function ownStateRun(
   task: LineageNode,
   ancestors: LineageNode[],
-  inState: (n: LineageNode) => boolean,
+  state: TransitionState,
 ): string[] {
   const ids: string[] = [];
-  if (inState(task)) ids.push(task.id);
+  if (task[state]) ids.push(task.id);
   for (const a of ancestors) {
-    if (!inState(a)) break;
+    if (!a[state]) break;
     ids.push(a.id);
   }
   return ids;
@@ -306,66 +392,54 @@ export function buildTransitionPlan(
   ancestors: LineageNode[],
   descendants: LineageNode[] = [],
 ): TransitionPlan {
+  const writes = buildWrites(kind, task, ancestors, descendants);
+  return { writes, events: planEvents(kind, task, writes) };
+}
+
+function buildWrites(
+  kind: TransitionKind,
+  task: LineageNode,
+  ancestors: LineageNode[],
+  descendants: LineageNode[],
+): PlanWrite[] {
   switch (kind) {
     case "COMPLETE":
-      return buildCompletePlan(task, descendants);
-    case "UNCOMPLETE":
-      return buildUncompletePlan(task, ancestors);
+      return cascade("completedAt", task, descendants);
     case "ARCHIVE":
-      return buildArchivePlan(task, descendants);
-    case "UNARCHIVE":
-      return buildUnarchivePlan(task, ancestors);
+      return cascade("archivedAt", task, descendants);
     case "DELETE":
-      return buildDeletePlan(task, descendants);
+      return cascade("deletedAt", task, descendants);
+    case "UNCOMPLETE":
+      return repair("completedAt", task, ancestors);
+    case "UNARCHIVE":
+      return repair("archivedAt", task, ancestors);
     case "UNDELETE":
-      return buildUndeletePlan(task, ancestors);
+      return repair("deletedAt", task, ancestors);
   }
 }
 
-function buildCompletePlan(
+/**
+ * Forward kinds: stamp the state on the target and every descendant below it
+ * that is not already in it, all sharing one date.
+ */
+function cascade(
+  state: TransitionState,
   task: LineageNode,
   descendants: LineageNode[],
-): TransitionPlan {
-  const ids = pruneCascade(task.id, descendants, (n) => !!n.completedAt);
-  return planWrite("completedAt", ids, new Date());
+): PlanWrite[] {
+  const ids = pruneCascade(task.id, descendants, state);
+  return writeOne(state, ids, new Date());
 }
 
-function buildUncompletePlan(
+/**
+ * Backward kinds: clear the state on the target and the unbroken run of
+ * ancestors that share it, so no task is left below one still in that state.
+ */
+function repair(
+  state: TransitionState,
   task: LineageNode,
   ancestors: LineageNode[],
-): TransitionPlan {
-  const ids = ownStateRun(task, ancestors, (n) => !!n.completedAt);
-  return planWrite("completedAt", ids, null);
-}
-
-function buildArchivePlan(
-  task: LineageNode,
-  descendants: LineageNode[],
-): TransitionPlan {
-  const ids = pruneCascade(task.id, descendants, (n) => !!n.archivedAt);
-  return planWrite("archivedAt", ids, new Date());
-}
-
-function buildUnarchivePlan(
-  task: LineageNode,
-  ancestors: LineageNode[],
-): TransitionPlan {
-  const ids = ownStateRun(task, ancestors, (n) => !!n.archivedAt);
-  return planWrite("archivedAt", ids, null);
-}
-
-function buildDeletePlan(
-  task: LineageNode,
-  descendants: LineageNode[],
-): TransitionPlan {
-  const ids = pruneCascade(task.id, descendants, (n) => !!n.deletedAt);
-  return planWrite("deletedAt", ids, new Date());
-}
-
-function buildUndeletePlan(
-  task: LineageNode,
-  ancestors: LineageNode[],
-): TransitionPlan {
-  const ids = ownStateRun(task, ancestors, (n) => !!n.deletedAt);
-  return planWrite("deletedAt", ids, null);
+): PlanWrite[] {
+  const ids = ownStateRun(task, ancestors, state);
+  return writeOne(state, ids, null);
 }

--- a/lib/services/task.service.ts
+++ b/lib/services/task.service.ts
@@ -11,8 +11,8 @@ import {
   validateTransition,
   buildTransitionPlan,
   type LineageNode,
+  type TransitionKind,
   type TransitionPlan,
-  type TransitionState,
 } from "../domain/taskHierarchyPolicy";
 
 // ─── Shared Helpers ────────────────────────────────────────────────────────────
@@ -77,36 +77,9 @@ async function collectDescendantNodes(
 }
 
 /**
- * Replay a plan's writes in order. The plan already decided which tasks change
- * and to what, so this stays a loop with no per-kind knowledge (#60).
- */
-async function executePlan(plan: TransitionPlan, tx: DbClient): Promise<void> {
-  for (const write of plan.writes) {
-    await tx.task.updateMany({
-      where: { id: { in: write.ids } },
-      data: { [write.state]: write.value },
-    });
-  }
-}
-
-/**
- * What the plan does to one state: the ids it writes and the value it stores.
- * Every plan today writes a given state at most once, so callers reporting a
- * count or emitting one event per changed task read it through here rather
- * than indexing into the write list. #62 moves event planning into the policy
- * and removes these lookups.
- */
-function writeFor(
-  plan: TransitionPlan,
-  state: TransitionState,
-): { ids: string[]; value: Date | null } {
-  return plan.writes.find((w) => w.state === state) ?? { ids: [], value: null };
-}
-
-/**
- * The six hierarchy-transition verbs. All share `statusTransitionPayload`
- * (`{at, causedBy?}`) in event.service, so a single payload shape is valid for
- * whichever verb this helper is handed.
+ * The six hierarchy-transition verbs as stored. All share
+ * `statusTransitionPayload` (`{at, causedBy?}`) in event.service, so a single
+ * payload shape is valid for whichever verb an event entry names.
  */
 type TransitionEventType =
   | typeof TaskEventType.COMPLETED
@@ -117,45 +90,205 @@ type TransitionEventType =
   | typeof TaskEventType.RESTORED;
 
 /**
- * Emit one TaskEvent per task changed by a hierarchy transition (ADR-0020).
- *
- * `changed` is the transition plan's slot for the flag this verb touches. Its
- * `ids` are already pruned, so descendants halted by the #44 stop rule — and any
- * task the transition left unchanged — are absent and emit nothing. Its `value`
- * is the stamped date, or null when the verb clears the flag (upward repairs) —
- * then the event time is the act's time, now. The direct target (`targetTaskId`)
- * gets `{at}`; every other changed task (a cascaded descendant, or an ancestor
- * repaired by an upward transition) gets `{at, causedBy: targetTaskId}` under
- * the SAME event `type`. Runs on the caller's `tx`, so a failure here rolls the
- * whole transition back.
+ * Domain kind → stored event type. The policy plans events in the domain's own
+ * words so it stays free of prisma (#59); this is the one place those words
+ * meet the ledger's.
  */
-async function emitTransitionEvents(
+const EVENT_TYPE_FOR: Record<TransitionKind, TransitionEventType> = {
+  COMPLETE: TaskEventType.COMPLETED,
+  UNCOMPLETE: TaskEventType.UNCOMPLETED,
+  ARCHIVE: TaskEventType.ARCHIVED,
+  UNARCHIVE: TaskEventType.UNARCHIVED,
+  DELETE: TaskEventType.DELETED,
+  UNDELETE: TaskEventType.RESTORED,
+};
+
+/**
+ * Run a plan: its writes, then its events, on the caller's transaction so a
+ * failure anywhere rolls the whole transition back (ADR-0020, CONTEXT.md
+ * invariant 2).
+ *
+ * The policy already decided which tasks change, to what, and who hears about
+ * it — including pruning the descendants the #44 stop rule halted — so this
+ * needs no knowledge of the kind that produced the plan (#60, #62).
+ */
+async function executePlan(
+  plan: TransitionPlan,
   tx: Prisma.TransactionClient,
-  {
-    type,
-    userId,
-    targetTaskId,
-    changed,
-  }: {
-    type: TransitionEventType;
-    userId: string;
-    targetTaskId: string;
-    changed: { ids: string[]; value: Date | null };
-  },
+  userId: string,
 ): Promise<void> {
-  const at = changed.value ?? new Date();
-  for (const id of changed.ids) {
+  for (const write of plan.writes) {
+    await tx.task.updateMany({
+      where: { id: { in: write.ids } },
+      data: { [write.state]: write.value },
+    });
+  }
+  for (const event of plan.events) {
     // Every `TransitionEventType` maps to the same `statusTransitionPayload`, so
-    // this input satisfies whichever of the six arms `type` selects — TS checks
+    // this input satisfies whichever of the six arms the type selects — TS checks
     // that by distributing the literal over the extracted union, no cast needed.
     const input: Extract<EmitEventInput, { type: TransitionEventType }> = {
-      taskId: id,
+      taskId: event.taskId,
       userId,
-      type,
-      payload: id === targetTaskId ? { at } : { at, causedBy: targetTaskId },
+      type: EVENT_TYPE_FOR[event.kind],
+      payload:
+        event.causedBy === undefined
+          ? { at: event.at }
+          : { at: event.at, causedBy: event.causedBy },
     };
     await emitEvent(tx, input);
   }
+}
+
+// ─── Hierarchy Transitions ─────────────────────────────────────────────────────
+
+/**
+ * All that differs between the six transitions. Everything else — the fetch,
+ * the auth check, the transaction, validate → plan → execute — is one fixed
+ * sequence in `applyTransition`, written once (#57, #62).
+ *
+ * `cascade` is set for exactly the three forward kinds. Reaching down the tree
+ * is what makes a kind need the descendant scan, and what makes a running
+ * timer somewhere below it a reason to refuse; backward kinds only repair
+ * upward, so they need neither.
+ *
+ * Which descendants a kind may touch is deliberately absent: that is the
+ * strength order's call, and the policy makes it (#62).
+ */
+const TRANSITIONS: Record<
+  TransitionKind,
+  {
+    failureMessage: string;
+    cascade: { timerBlockedMessage: string } | null;
+  }
+> = {
+  COMPLETE: {
+    failureMessage: "Failed to complete task",
+    cascade: {
+      timerBlockedMessage:
+        "Task with active Timer cannot be marked as complete",
+    },
+  },
+  ARCHIVE: {
+    failureMessage: "Failed to archive task",
+    cascade: { timerBlockedMessage: "Task with active Timer cannot be archived" },
+  },
+  DELETE: {
+    failureMessage: "Failed to delete task",
+    cascade: { timerBlockedMessage: "Task with active Timer cannot be deleted" },
+  },
+  UNCOMPLETE: { failureMessage: "Failed to uncomplete task", cascade: null },
+  UNARCHIVE: { failureMessage: "Failed to unarchive task", cascade: null },
+  UNDELETE: { failureMessage: "Failed to restore task", cascade: null },
+};
+
+/** The target as `applyTransition` fetches it: what the policy judges, plus
+ *  what the auth check and the parent-trail event need. */
+type TransitionTarget = LineageNode & {
+  title: string;
+  projectId: string;
+  project: { userId: string };
+};
+
+/** How many tasks a plan touches — a task counts once even if several writes name it. */
+function countChanged(plan: TransitionPlan): number {
+  return new Set(plan.writes.flatMap((w) => w.ids)).size;
+}
+
+/**
+ * The one path every hierarchy transition takes (#57, #62).
+ *
+ * Legality is the policy's alone: the fetch filters on nothing but the id, so
+ * a task in the wrong state reaches `validateTransition` and gets a real
+ * reason back, instead of being masked as NOT_FOUND by a `where` clause that
+ * quietly encoded the same rule a second time.
+ *
+ * `afterPlan` is for ledger work a kind owes beyond its own transition —
+ * today only DELETE, which also marks the removal on the parent's trail. It
+ * runs on the same transaction, so it rolls back with everything else.
+ */
+async function applyTransition({
+  kind,
+  taskId,
+  userId,
+  afterPlan,
+}: {
+  kind: TransitionKind;
+  taskId: string;
+  userId: string;
+  afterPlan?: (
+    tx: Prisma.TransactionClient,
+    task: TransitionTarget,
+  ) => Promise<void>;
+}) {
+  const config = TRANSITIONS[kind];
+  return serviceAction(async () => {
+    const task = await client.task.findUnique({
+      where: { id: taskId },
+      select: {
+        id: true,
+        title: true,
+        parentId: true,
+        projectId: true,
+        completedAt: true,
+        archivedAt: true,
+        deletedAt: true,
+        project: { select: { userId: true } },
+      },
+    });
+    if (!task) {
+      return createServiceErrorResponse("NOT_FOUND", "Task not found");
+    }
+    if (task.project.userId !== userId) {
+      return createServiceErrorResponse(
+        "AUTHORIZATION_ERROR",
+        "User does not have access to this task",
+      );
+    }
+
+    return await client.$transaction(async (tx) => {
+      const ancestors = await getAllAncestors(task.parentId, tx);
+      const validation = validateTransition(kind, task, ancestors);
+      if (!validation.valid) {
+        return createServiceErrorResponse(
+          validation.error.code,
+          validation.error.message,
+        );
+      }
+
+      let descendants: LineageNode[] = [];
+      if (config.cascade) {
+        // The whole subtree, in whatever state. The policy's strength order
+        // decides how far the cascade actually reaches, so filtering here
+        // would be the same rule written a second time (#62).
+        descendants = await collectDescendantNodes(
+          taskId,
+          task.projectId,
+          tx,
+          true,
+          true,
+        );
+        const activeTimer = await tx.activeTimer.findFirst({
+          where: { taskId: { in: descendants.map((d) => d.id) } },
+        });
+        if (activeTimer) {
+          return createServiceErrorResponse(
+            "VALIDATION_ERROR",
+            config.cascade.timerBlockedMessage,
+          );
+        }
+      }
+
+      const plan = buildTransitionPlan(kind, task, ancestors, descendants);
+      await executePlan(plan, tx, userId);
+      await afterPlan?.(tx, task);
+
+      return createSuccessResponseWithData({
+        id: taskId,
+        changedCount: countChanged(plan),
+      });
+    });
+  }, config.failureMessage);
 }
 
 async function getAllAncestors(
@@ -403,87 +536,24 @@ export function deleteTask({
   taskId: string;
   userId: string;
 }) {
-  return serviceAction(async () => {
-    const task = await client.task.findUnique({
-      where: { id: taskId, deletedAt: null },
-      select: {
-        id: true,
-        title: true, // for the SUBTASK_REMOVED payload on the parent (#52)
-        parentId: true,
-        projectId: true,
-        completedAt: true,
-        archivedAt: true,
-        deletedAt: true,
-        project: { select: { userId: true } },
-      },
-    });
-
-    if (!task) {
-      return createServiceErrorResponse("NOT_FOUND", "Task not found");
-    }
-
-    if (task.project.userId !== userId) {
-      return createServiceErrorResponse(
-        "AUTHORIZATION_ERROR",
-        "User does not have access to this task",
-      );
-    }
-
-    return await client.$transaction(async (tx) => {
-      const ancestors = await getAllAncestors(task.parentId, tx);
-      const validation = validateTransition("DELETE", task, ancestors);
-      if (!validation.valid) {
-        return createServiceErrorResponse(
-          validation.error.code,
-          validation.error.message,
-        );
-      }
-
-      const descendants = await collectDescendantNodes(
-        taskId,
-        task.projectId,
-        tx,
-        true,
-      );
-
-      const activeTimer = await tx.activeTimer.findFirst({
-        where: { taskId: { in: descendants.map((d) => d.id) } },
-      });
-
-      if (activeTimer) {
-        return createServiceErrorResponse(
-          "VALIDATION_ERROR",
-          "Task with active Timer cannot be deleted",
-        );
-      }
-
-      const plan = buildTransitionPlan("DELETE", task, ancestors, descendants);
-      await executePlan(plan, tx);
-      await emitTransitionEvents(tx, {
-        type: TaskEventType.DELETED,
-        userId,
-        targetTaskId: task.id,
-        changed: writeFor(plan, "deletedAt"),
-      });
-
+  return applyTransition({
+    kind: "DELETE",
+    taskId,
+    userId,
+    afterPlan: async (tx, task) => {
       // Record the removal on the former direct parent's trail (#52). Only the
       // directly-deleted task notifies its parent; descendants swept up by the
-      // same cascade do not emit (ADR-0020 boundary).
-      if (task.parentId) {
-        await emitEvent(tx, {
-          taskId: task.parentId,
-          userId,
-          type: TaskEventType.SUBTASK_REMOVED,
-          payload: { childTaskId: task.id, childTitle: task.title },
-        });
-      }
-
-      return createSuccessResponseWithData({
-        id: taskId,
-        deletedCount: writeFor(plan, "deletedAt").ids.length,
+      // same cascade do not emit (ADR-0020 boundary). Not a transition event,
+      // so it rides alongside the plan rather than in it.
+      if (!task.parentId) return;
+      await emitEvent(tx, {
+        taskId: task.parentId,
+        userId,
+        type: TaskEventType.SUBTASK_REMOVED,
+        payload: { childTaskId: task.id, childTitle: task.title },
       });
-    });
-  }, "Failed to delete task");
+    },
+  });
 }
 
 export function hasActiveDescendants({ taskId }: { taskId: string }) {
@@ -510,76 +580,7 @@ export function completeTask({
   taskId: string;
   userId: string;
 }) {
-  return serviceAction(async () => {
-    const task = await client.task.findUnique({
-      where: { id: taskId, deletedAt: null },
-      select: {
-        id: true,
-        parentId: true,
-        projectId: true,
-        completedAt: true,
-        archivedAt: true,
-        deletedAt: true,
-        project: { select: { userId: true } },
-      },
-    });
-
-    if (!task) {
-      return createServiceErrorResponse("NOT_FOUND", "Task not found");
-    }
-    if (task.project.userId !== userId) {
-      return createServiceErrorResponse(
-        "AUTHORIZATION_ERROR",
-        "User does not have access to this task",
-      );
-    }
-
-    return await client.$transaction(async (tx) => {
-      const ancestors = await getAllAncestors(task.parentId, tx);
-      const validation = validateTransition("COMPLETE", task, ancestors);
-      if (!validation.valid) {
-        return createServiceErrorResponse(
-          validation.error.code,
-          validation.error.message,
-        );
-      }
-
-      const descendants = await collectDescendantNodes(
-        taskId,
-        task.projectId,
-        tx,
-      );
-
-      const activeTimer = await tx.activeTimer.findFirst({
-        where: { taskId: { in: descendants.map((d) => d.id) } },
-      });
-      if (activeTimer) {
-        return createServiceErrorResponse(
-          "VALIDATION_ERROR",
-          "Task with active Timer cannot be marked as complete",
-        );
-      }
-
-      const plan = buildTransitionPlan(
-        "COMPLETE",
-        task,
-        ancestors,
-        descendants,
-      );
-      await executePlan(plan, tx);
-      await emitTransitionEvents(tx, {
-        type: TaskEventType.COMPLETED,
-        userId,
-        targetTaskId: task.id,
-        changed: writeFor(plan, "completedAt"),
-      });
-
-      return createSuccessResponseWithData({
-        id: taskId,
-        completedCount: writeFor(plan, "completedAt").ids.length,
-      });
-    });
-  }, "Failed to complete task");
+  return applyTransition({ kind: "COMPLETE", taskId, userId });
 }
 
 export function uncompleteTask({
@@ -589,60 +590,8 @@ export function uncompleteTask({
   taskId: string;
   userId: string;
 }) {
-  return serviceAction(async () => {
-    const task = await client.task.findUnique({
-      where: {
-        id: taskId,
-        deletedAt: null,
-      },
-      select: {
-        id: true,
-        parentId: true,
-        completedAt: true,
-        archivedAt: true,
-        deletedAt: true,
-        project: { select: { userId: true } },
-      },
-    });
-
-    if (!task) {
-      return createServiceErrorResponse("NOT_FOUND", "Task not found");
-    }
-    if (task.project.userId !== userId) {
-      return createServiceErrorResponse(
-        "AUTHORIZATION_ERROR",
-        "User does not have access to this task",
-      );
-    }
-
-    return await client.$transaction(async (tx) => {
-      const ancestors = await getAllAncestors(task.parentId, tx);
-      const validation = validateTransition("UNCOMPLETE", task, ancestors);
-      if (!validation.valid) {
-        return createServiceErrorResponse(
-          validation.error.code,
-          validation.error.message,
-        );
-      }
-
-      const plan = buildTransitionPlan("UNCOMPLETE", task, ancestors);
-      await executePlan(plan, tx);
-      await emitTransitionEvents(tx, {
-        type: TaskEventType.UNCOMPLETED,
-        userId,
-        targetTaskId: task.id,
-        changed: writeFor(plan, "completedAt"),
-      });
-
-      return createSuccessResponseWithData({
-        id: taskId,
-        uncompletedCount: writeFor(plan, "completedAt").ids.length,
-      });
-    });
-  }, "Failed to uncomplete task");
+  return applyTransition({ kind: "UNCOMPLETE", taskId, userId });
 }
-
-// ─── Archive / Unarchive / Restore ─────────────────────────────────────────────
 
 export function archiveTask({
   taskId,
@@ -651,76 +600,7 @@ export function archiveTask({
   taskId: string;
   userId: string;
 }) {
-  return serviceAction(async () => {
-    const task = await client.task.findUnique({
-      where: { id: taskId, deletedAt: null, archivedAt: null },
-      select: {
-        id: true,
-        parentId: true,
-        projectId: true,
-        completedAt: true,
-        archivedAt: true,
-        deletedAt: true,
-        project: { select: { userId: true } },
-      },
-    });
-
-    if (!task) {
-      return createServiceErrorResponse("NOT_FOUND", "Task not found");
-    }
-    if (task.project.userId !== userId) {
-      return createServiceErrorResponse(
-        "AUTHORIZATION_ERROR",
-        "User does not have access to this task",
-      );
-    }
-
-    return await client.$transaction(async (tx) => {
-      const ancestors = await getAllAncestors(task.parentId, tx);
-      const validation = validateTransition("ARCHIVE", task, ancestors);
-      if (!validation.valid) {
-        return createServiceErrorResponse(
-          validation.error.code,
-          validation.error.message,
-        );
-      }
-
-      const descendants = await collectDescendantNodes(
-        taskId,
-        task.projectId,
-        tx,
-      );
-
-      const activeTimer = await tx.activeTimer.findFirst({
-        where: { taskId: { in: descendants.map((d) => d.id) } },
-      });
-      if (activeTimer) {
-        return createServiceErrorResponse(
-          "VALIDATION_ERROR",
-          "Task with active Timer cannot be archived",
-        );
-      }
-
-      const plan = buildTransitionPlan(
-        "ARCHIVE",
-        task,
-        ancestors,
-        descendants,
-      );
-      await executePlan(plan, tx);
-      await emitTransitionEvents(tx, {
-        type: TaskEventType.ARCHIVED,
-        userId,
-        targetTaskId: task.id,
-        changed: writeFor(plan, "archivedAt"),
-      });
-
-      return createSuccessResponseWithData({
-        id: taskId,
-        archivedCount: writeFor(plan, "archivedAt").ids.length,
-      });
-    });
-  }, "Failed to archive task");
+  return applyTransition({ kind: "ARCHIVE", taskId, userId });
 }
 
 export function unarchiveTask({
@@ -730,51 +610,7 @@ export function unarchiveTask({
   taskId: string;
   userId: string;
 }) {
-  return serviceAction(async () => {
-    const task = await client.task.findUnique({
-      where: { id: taskId, archivedAt: { not: null }, deletedAt: null },
-      select: {
-        id: true,
-        parentId: true,
-        completedAt: true,
-        archivedAt: true,
-        deletedAt: true,
-        project: { select: { userId: true } },
-      },
-    });
-
-    if (!task) {
-      return createServiceErrorResponse("NOT_FOUND", "Task not found");
-    }
-    if (task.project.userId !== userId) {
-      return createServiceErrorResponse(
-        "AUTHORIZATION_ERROR",
-        "User does not have access to this task",
-      );
-    }
-
-    return await client.$transaction(async (tx) => {
-      const ancestors = await getAllAncestors(task.parentId, tx);
-      const validation = validateTransition("UNARCHIVE", task, ancestors);
-      if (!validation.valid) {
-        return createServiceErrorResponse(
-          validation.error.code,
-          validation.error.message,
-        );
-      }
-
-      const plan = buildTransitionPlan("UNARCHIVE", task, ancestors);
-      await executePlan(plan, tx);
-      await emitTransitionEvents(tx, {
-        type: TaskEventType.UNARCHIVED,
-        userId,
-        targetTaskId: task.id,
-        changed: writeFor(plan, "archivedAt"),
-      });
-
-      return createSuccessResponseWithData({ id: taskId });
-    });
-  }, "Failed to unarchive task");
+  return applyTransition({ kind: "UNARCHIVE", taskId, userId });
 }
 
 export function restoreDeletedTask({
@@ -784,52 +620,5 @@ export function restoreDeletedTask({
   taskId: string;
   userId: string;
 }) {
-  return serviceAction(async () => {
-    const task = await client.task.findUnique({
-      where: { id: taskId, deletedAt: { not: null } },
-      select: {
-        id: true,
-        parentId: true,
-        completedAt: true,
-        archivedAt: true,
-        deletedAt: true,
-        project: { select: { userId: true } },
-      },
-    });
-
-    if (!task) {
-      return createServiceErrorResponse("NOT_FOUND", "Task not found");
-    }
-    if (task.project.userId !== userId) {
-      return createServiceErrorResponse(
-        "AUTHORIZATION_ERROR",
-        "User does not have access to this task",
-      );
-    }
-
-    return await client.$transaction(async (tx) => {
-      const ancestors = await getAllAncestors(task.parentId, tx);
-      const validation = validateTransition("UNDELETE", task, ancestors);
-      if (!validation.valid) {
-        return createServiceErrorResponse(
-          validation.error.code,
-          validation.error.message,
-        );
-      }
-
-      const plan = buildTransitionPlan("UNDELETE", task, ancestors);
-      await executePlan(plan, tx);
-      await emitTransitionEvents(tx, {
-        type: TaskEventType.RESTORED,
-        userId,
-        targetTaskId: task.id,
-        changed: writeFor(plan, "deletedAt"),
-      });
-
-      return createSuccessResponseWithData({
-        id: taskId,
-        restoredCount: writeFor(plan, "deletedAt").ids.length,
-      });
-    });
-  }, "Failed to restore task");
+  return applyTransition({ kind: "UNDELETE", taskId, userId });
 }

--- a/tests/unit/domain/taskHierarchyPolicy.test.ts
+++ b/tests/unit/domain/taskHierarchyPolicy.test.ts
@@ -551,3 +551,127 @@ describe("buildTransitionPlan — UNDELETE", () => {
     expect(states(plan)).toEqual(["deletedAt"]);
   });
 });
+
+// ─── buildTransitionPlan: the strength order ───────────────────────────────────
+
+// delete > archive > complete (#57). A forward kind cascades through states
+// strictly weaker than its own and stops at equal-or-stronger, keeping the
+// stronger state's date. The order alone decides — the caller does not get to
+// pre-filter the subtree into agreement.
+describe("buildTransitionPlan — strength order delete > archive > complete", () => {
+  it("COMPLETE stops at an archived descendant and never walks below it", () => {
+    const task = node("t1", null);
+    const descendants = [
+      task,
+      node("t2", "t1", { archivedAt: now }), // stronger — stop, keep its date
+      node("t3", "t2"), // below the stop — untouched
+      node("t4", "t1"), // sibling — still completed
+    ];
+    const plan = buildTransitionPlan("COMPLETE", task, [], descendants);
+    expect(ids(plan, "completedAt")).toEqual(["t1", "t4"]);
+  });
+
+  it("COMPLETE stops at a deleted descendant", () => {
+    const task = node("t1", null);
+    const descendants = [task, node("t2", "t1", { deletedAt: now })];
+    const plan = buildTransitionPlan("COMPLETE", task, [], descendants);
+    expect(ids(plan, "completedAt")).toEqual(["t1"]);
+  });
+
+  it("ARCHIVE stops at a deleted descendant but cascades through a completed one", () => {
+    const task = node("t1", null);
+    const descendants = [
+      task,
+      node("t2", "t1", { completedAt: now }), // weaker — archive passes through
+      node("t3", "t2"), // still reached, below the completed one
+      node("t4", "t1", { deletedAt: now }), // stronger — stop
+      node("t5", "t4"), // below the stop — untouched
+    ];
+    const plan = buildTransitionPlan("ARCHIVE", task, [], descendants);
+    expect(ids(plan, "archivedAt")).toEqual(["t1", "t2", "t3"]);
+  });
+
+  it("DELETE cascades through both weaker states, stopping only at deleted", () => {
+    const task = node("t1", null);
+    const descendants = [
+      task,
+      node("t2", "t1", { completedAt: now }), // weaker — pass through
+      node("t3", "t1", { archivedAt: now }), // weaker — pass through
+      node("t4", "t3"), // still reached, below the archived one
+      node("t5", "t1", { deletedAt: now }), // equal — stop, keep its date
+    ];
+    const plan = buildTransitionPlan("DELETE", task, [], descendants);
+    expect(ids(plan, "deletedAt")).toEqual(["t1", "t2", "t3", "t4"]);
+  });
+});
+
+// ─── buildTransitionPlan: events ───────────────────────────────────────────────
+
+describe("buildTransitionPlan — events", () => {
+  it("plans one event per changed task, target first and without causedBy", () => {
+    const task = node("t1", null);
+    const descendants = [task, node("t2", "t1"), node("t3", "t2")];
+    const plan = buildTransitionPlan("COMPLETE", task, [], descendants);
+    expect(plan.events).toEqual([
+      { kind: "COMPLETE", taskId: "t1", at: value(plan, "completedAt") },
+      {
+        kind: "COMPLETE",
+        taskId: "t2",
+        at: value(plan, "completedAt"),
+        causedBy: "t1",
+      },
+      {
+        kind: "COMPLETE",
+        taskId: "t3",
+        at: value(plan, "completedAt"),
+        causedBy: "t1",
+      },
+    ]);
+  });
+
+  it("stamps forward events with the date the plan stores", () => {
+    const task = node("t1", null);
+    const plan = buildTransitionPlan("ARCHIVE", task, [], [task]);
+    expect(plan.events[0].at).toBe(value(plan, "archivedAt"));
+  });
+
+  it("stamps backward events with now, since the plan stores null", () => {
+    const task = node("t2", "t1", { completedAt: now });
+    const ancestors = [node("t1", null, { completedAt: now })];
+    const plan = buildTransitionPlan("UNCOMPLETE", task, ancestors);
+    expect(value(plan, "completedAt")).toBeNull();
+    expect(plan.events.map((e) => e.at)).toEqual([
+      expect.any(Date),
+      expect.any(Date),
+    ]);
+    expect(plan.events[0].at.getTime()).toBeGreaterThan(now.getTime());
+  });
+
+  it("marks ancestors repaired by a backward transition as caused by the target", () => {
+    const task = node("t2", "t1", { archivedAt: now });
+    const ancestors = [node("t1", null, { archivedAt: now })];
+    const plan = buildTransitionPlan("UNARCHIVE", task, ancestors);
+    expect(plan.events.map((e) => [e.taskId, e.causedBy])).toEqual([
+      ["t2", undefined],
+      ["t1", "t2"],
+    ]);
+  });
+
+  it("skips descendants the stop rule pruned", () => {
+    const task = node("t1", null);
+    const descendants = [
+      task,
+      node("t2", "t1", { deletedAt: now }), // stop — keeps its date, emits nothing
+      node("t3", "t1"),
+    ];
+    const plan = buildTransitionPlan("DELETE", task, [], descendants);
+    expect(plan.events.map((e) => e.taskId)).toEqual(["t1", "t3"]);
+  });
+
+  it("plans no events when the transition writes nothing", () => {
+    const task = node("t2", "t1");
+    const plan = buildTransitionPlan("UNCOMPLETE", task, [node("t1", null)]);
+    expect(plan.writes).toEqual([]);
+    expect(plan.events).toEqual([]);
+  });
+});

--- a/tests/unit/services/task.service.test.ts
+++ b/tests/unit/services/task.service.test.ts
@@ -19,7 +19,10 @@ import {
   createTask,
   deleteTask,
   completeTask,
+  uncompleteTask,
   archiveTask,
+  unarchiveTask,
+  restoreDeletedTask,
 } from "@/lib/services/task.service";
 import prisma from "@/lib/prisma";
 
@@ -281,6 +284,171 @@ describe("createTask — SUBTASK_CREATED events", () => {
 
     expect(result.success).toBe(true);
     expect(subtaskEventCalls(TaskEventType.SUBTASK_CREATED)).toHaveLength(0);
+  });
+});
+
+// The orchestrator's own contract (#62). The fetch filters on nothing but the
+// id, so a task in the wrong state now reaches the policy and comes back with
+// a real reason. Before, a per-kind `where` clause hid it as NOT_FOUND — the
+// same rule written twice, disagreeing about what the user did wrong.
+describe("applyTransition — the policy alone judges legality", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db.$transaction.mockImplementation((fn: (tx: MockTx) => unknown) => fn(tx));
+    tx.activeTimer.findFirst.mockResolvedValue(null);
+    tx.task.updateMany.mockResolvedValue({ count: 1 });
+    tx.taskEvent.create.mockResolvedValue({ id: "event-1" });
+    tx.task.findUnique.mockResolvedValue(null); // no ancestors
+    tx.task.findMany.mockResolvedValue([]);
+  });
+
+  const targetInState = (overrides: Record<string, unknown>) =>
+    buildTask({
+      id: "t1",
+      parentId: null,
+      project: { userId: "test-user-1" },
+      ...overrides,
+    });
+
+  // This is the assertion that pins the change. The prisma mock ignores `where`,
+  // so a test that only reads the returned error would pass against the old
+  // per-kind filters too; the fetch shape is what actually tells them apart.
+  it.each([
+    ["completeTask", completeTask],
+    ["uncompleteTask", uncompleteTask],
+    ["archiveTask", archiveTask],
+    ["unarchiveTask", unarchiveTask],
+    ["deleteTask", deleteTask],
+    ["restoreDeletedTask", restoreDeletedTask],
+  ])("%s fetches by id alone, with no state filter", async (_name, run) => {
+    db.task.findUnique.mockResolvedValue(
+      targetInState({ archivedAt: new Date(), deletedAt: new Date() }),
+    );
+    tx.task.findMany.mockResolvedValue([lineageNode("t1", null)]);
+
+    await run({ taskId: "t1", userId: "test-user-1" });
+
+    expect(db.task.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "t1" } }),
+    );
+  });
+
+  it.each([
+    ["archiveTask on an already-archived task", archiveTask, { archivedAt: new Date() }, "Task is already archived"],
+    ["unarchiveTask on a task that is not archived", unarchiveTask, {}, "Task is not archived"],
+    ["restoreDeletedTask on a task that is not deleted", restoreDeletedTask, {}, "Task is not deleted"],
+    ["completeTask on a deleted task", completeTask, { deletedAt: new Date() }, "Task is deleted"],
+    ["uncompleteTask on a task that is not completed", uncompleteTask, {}, "Task is not completed"],
+  ])("%s says why, instead of NOT_FOUND", async (_name, run, state, reason) => {
+    db.task.findUnique.mockResolvedValue(targetInState(state));
+
+    const result = await run({ taskId: "t1", userId: "test-user-1" });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.message).toBe(reason);
+      expect(result.error.code).not.toBe("NOT_FOUND");
+    }
+  });
+
+  it("still reports NOT_FOUND when the task really does not exist", async () => {
+    db.task.findUnique.mockResolvedValue(null);
+
+    const result = await completeTask({ taskId: "gone", userId: "test-user-1" });
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.code).toBe("NOT_FOUND");
+  });
+
+  it("checks the owner before opening a transaction", async () => {
+    db.task.findUnique.mockResolvedValue(
+      targetInState({ project: { userId: "someone-else" } }),
+    );
+
+    const result = await completeTask({ taskId: "t1", userId: "test-user-1" });
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.code).toBe("AUTHORIZATION_ERROR");
+    expect(db.$transaction).not.toHaveBeenCalled();
+  });
+});
+
+// The timer guard belongs to the kinds that reach down the tree: a running
+// timer below the target is only a problem when the target's state is about to
+// land on it. Backward kinds repair upward and never scan.
+describe("applyTransition — timer guard on the forward kinds only", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db.$transaction.mockImplementation((fn: (tx: MockTx) => unknown) => fn(tx));
+    tx.task.updateMany.mockResolvedValue({ count: 1 });
+    tx.taskEvent.create.mockResolvedValue({ id: "event-1" });
+    tx.task.findUnique.mockResolvedValue(null);
+    tx.task.findMany.mockResolvedValue([lineageNode("t1", null)]);
+  });
+
+  it.each([
+    ["completeTask", completeTask, "Task with active Timer cannot be marked as complete"],
+    ["archiveTask", archiveTask, "Task with active Timer cannot be archived"],
+    ["deleteTask", deleteTask, "Task with active Timer cannot be deleted"],
+  ])("%s refuses while a timer runs in the subtree", async (_name, run, message) => {
+    db.task.findUnique.mockResolvedValue(
+      buildTask({ id: "t1", parentId: null, project: { userId: "test-user-1" } }),
+    );
+    tx.activeTimer.findFirst.mockResolvedValue(buildActiveTimer({ taskId: "t1" }));
+
+    const result = await run({ taskId: "t1", userId: "test-user-1" });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.code).toBe("VALIDATION_ERROR");
+      expect(result.error.message).toBe(message);
+    }
+    expect(tx.task.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("unarchiveTask never scans for descendants or timers", async () => {
+    db.task.findUnique.mockResolvedValue(
+      buildTask({
+        id: "t1",
+        parentId: null,
+        archivedAt: new Date(),
+        project: { userId: "test-user-1" },
+      }),
+    );
+    tx.activeTimer.findFirst.mockResolvedValue(buildActiveTimer({ taskId: "t1" }));
+
+    const result = await unarchiveTask({ taskId: "t1", userId: "test-user-1" });
+
+    expect(result.success).toBe(true);
+    expect(tx.activeTimer.findFirst).not.toHaveBeenCalled();
+    expect(tx.task.findMany).not.toHaveBeenCalled();
+  });
+
+  // How far a cascade reaches is the strength order's call. The service used to
+  // encode part of it in the descendant fetch — DELETE included archived rows,
+  // COMPLETE and ARCHIVE did not — which left the rule in two places. Now every
+  // forward kind hands the policy the whole subtree.
+  it.each([
+    ["completeTask", completeTask],
+    ["archiveTask", archiveTask],
+    ["deleteTask", deleteTask],
+  ])("%s scans the whole subtree, in whatever state", async (_name, run) => {
+    db.task.findUnique.mockResolvedValue(
+      buildTask({
+        id: "t1",
+        parentId: null,
+        project: { userId: "test-user-1" },
+      }),
+    );
+    tx.activeTimer.findFirst.mockResolvedValue(null);
+
+    await run({ taskId: "t1", userId: "test-user-1" });
+
+    expect(tx.task.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { projectId: "test-project-1", archivedAt: undefined, deletedAt: undefined },
+      }),
+    );
   });
 });
 


### PR DESCRIPTION
Closes #62. Part of #57. Together with #78 this closes #54: the own-act events land here, the inherit events land in #78.

**Stacked on #76 (#60)**, which is stacked on #75 (#59). Base is `feat/60-transition-plan-writes`. Read the last commit only, or wait for the two below to land.

## What

The six transition functions were one sequence copy-pasted six times — fetch, auth, transaction, validate, plan, execute, emit. They differed only in a per-kind `where` filter, whether they scanned descendants, and their messages. `applyTransition` holds that sequence once; the six exports stay as one-liners over it, so `task.actions.ts` keeps importing the same names.

`task.service.ts`: 828 → 624 lines.

### Legality is the policy's alone

The fetch now filters on the id and nothing else. Those `where` clauses (`archivedAt: null`, `deletedAt: { not: null }`, …) were the transition rules written a second time — and they disagreed with the policy about what the user did wrong: unarchiving a task that is not archived answered "Task not found" instead of "Task is not archived". Dropping the masking is deliberate per #57.

### One strength order drives the cascade

`delete > archive > complete` now lives in the policy and decides the stop rule. It used to live in the **descendant fetch** — DELETE included archived rows, COMPLETE and ARCHIVE did not — so the caller pre-filtered the subtree into agreement and the rule sat in two places. The policy now takes the whole subtree and decides how far the cascade reaches. This was an acceptance criterion I nearly missed; the three tests that cover it were red before the change.

### Events ride the plan (#54)

The policy plans one event per task its **own-state** write touches (`OWN_STATE` maps each kind to the flag it is about). `executePlan` inserts writes and events on the same transaction. Emission lands once instead of six times.

The policy names events in domain words (`TransitionKind`); the service maps them to `TaskEventType`. That is what keeps `lib/domain/` prisma-free (#59) — the module still has **zero imports**. It also sets up #63: an inherit write is not an own-state write, so it gets no event *here* — #63 (next in the stack) gives inherit writes their own events, caused by the ancestor the state came from.

## Behavior changes (intended)

- Wrong-state transitions return their real reason instead of `NOT_FOUND`.
- The five per-kind `*Count` response fields (`deletedCount`, `archivedCount`, …; `unarchiveTask` returned a bare `{ id }`) were read by **nobody** — not the actions, not the UI, not the tests. Replaced with one kind-agnostic `changedCount`. Say the word if you want them back.

## Verify

- **224/224 tests pass**, `tsc --noEmit` clean.
- New tests: fetch shape for all six kinds, auth before the transaction opens, timer guard on the forward kinds only, and the strength order.
- One caveat worth knowing: the prisma mock ignores `where`, so a test that only reads the returned error would pass against the old filters too. The fetch-shape assertion is what actually pins this change — I checked it fails when a per-kind filter is put back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
