### PR TITLE
Backward transitions inherit weaker states from ancestors (#63)

### DIFF
--- a/lib/domain/taskHierarchyPolicy.ts
+++ b/lib/domain/taskHierarchyPolicy.ts
@@ -55,8 +55,10 @@ export type PlanWrite = {
 
 /**
  * One entry for the audit ledger: this task changed, at this time, because of
- * this transition. `causedBy` names the task the user actually acted on, and
- * is set on every task except that target (ADR-0020).
+ * this transition. `causedBy` names the task that caused the change: the task
+ * the user actually acted on for cascade and repair events, or the ancestor
+ * whose state was taken on for inherit events. Only the acted-on target
+ * itself carries no `causedBy` (ADR-0020).
  *
  * `kind` stays domain vocabulary — mapping it to a stored event type is the
  * service's job, which is what keeps this module free of prisma (#59).
@@ -94,9 +96,10 @@ function writeOne(
  * The state a kind is *about* — the flag it sets or clears on the target. Both
  * directions of a pair share one state, since they move along the same axis.
  *
- * Only writes to this state are the transition's own act, so only they are
- * worth an event. A write to any other state is a side effect the transition
- * makes to keep the tree legal (#63's backdated inherits), and stays silent.
+ * Only writes to this state are the transition's own act. A write to any other
+ * state is a repair the transition makes to keep the tree legal (#63's
+ * backdated inherits) — still a state change, so it gets its own event too,
+ * planned where the repair is decided (`inheritWeakerStates`).
  */
 const OWN_STATE: Record<TransitionKind, TransitionState> = {
   COMPLETE: "completedAt",
@@ -105,6 +108,17 @@ const OWN_STATE: Record<TransitionKind, TransitionState> = {
   UNARCHIVE: "archivedAt",
   DELETE: "deletedAt",
   UNDELETE: "deletedAt",
+};
+
+/**
+ * The forward kind that sets each state — `OWN_STATE` read backwards, keeping
+ * only the setting direction. An inherit event uses it: a task taking on
+ * `archivedAt` was archived, whichever transition made it happen.
+ */
+const KIND_THAT_SETS: Record<TransitionState, TransitionKind> = {
+  completedAt: "COMPLETE",
+  archivedAt: "ARCHIVE",
+  deletedAt: "DELETE",
 };
 
 /**
@@ -392,16 +406,27 @@ export function buildTransitionPlan(
   ancestors: LineageNode[],
   descendants: LineageNode[] = [],
 ): TransitionPlan {
-  const writes = buildWrites(kind, task, ancestors, descendants);
-  return { writes, events: planEvents(kind, task, writes) };
+  const { writes, events: inheritEvents } = buildWrites(
+    kind,
+    task,
+    ancestors,
+    descendants,
+  );
+  return { writes, events: [...planEvents(kind, task, writes), ...inheritEvents] };
 }
 
+/**
+ * The writes, plus the events only the write-building knows about: inherit
+ * events name the ancestor a state came from, and `inheritWeakerStates` is
+ * the only place that knows the source. Own-act events are planned from the
+ * finished writes in `planEvents`.
+ */
 function buildWrites(
   kind: TransitionKind,
   task: LineageNode,
   ancestors: LineageNode[],
   descendants: LineageNode[],
-): PlanWrite[] {
+): TransitionPlan {
   switch (kind) {
     case "COMPLETE":
       return cascade("completedAt", task, descendants);
@@ -426,20 +451,126 @@ function cascade(
   state: TransitionState,
   task: LineageNode,
   descendants: LineageNode[],
-): PlanWrite[] {
+): TransitionPlan {
   const ids = pruneCascade(task.id, descendants, state);
-  return writeOne(state, ids, new Date());
+  return { writes: writeOne(state, ids, new Date()), events: [] };
 }
 
 /**
  * Backward kinds: clear the state on the target and the unbroken run of
  * ancestors that share it, so no task is left below one still in that state.
+ *
+ * Clearing it also removes the cover it gave. A task parked under a stronger
+ * state is allowed to sit outside the weaker ones its ancestors hold — the
+ * forward cascade stopped at it and kept its date (#44). Take the stronger
+ * state away and that becomes a gap the tree forbids (invariant 5), so the
+ * repaired tasks take those weaker states on, backdated to the ancestor's own
+ * date rather than stamped with now (#57, #63).
  */
 function repair(
   state: TransitionState,
   task: LineageNode,
   ancestors: LineageNode[],
-): PlanWrite[] {
+): TransitionPlan {
   const ids = ownStateRun(task, ancestors, state);
-  return writeOne(state, ids, null);
+  if (ids.length === 0) return { writes: [], events: [] };
+  const inherited = inheritWeakerStates(state, ids, [task, ...ancestors]);
+  return {
+    writes: [{ state, ids, value: null }, ...inherited.writes],
+    events: inherited.events,
+  };
+}
+
+/**
+ * What the repaired tasks must take on from the ancestors above them.
+ *
+ * Reads the chain from the root down, carrying each weaker state's date as far
+ * as it applies. A task that holds something stronger is already covered and
+ * takes on nothing; a task whose parent does not hold the state has nothing to
+ * take. Strongest state first, so a cover pulled in on one pass is known to
+ * the next.
+ *
+ * Each state taken on is a change of its own, so it also gets an event: the
+ * forward kind that sets the state, caused by the ancestor the state came
+ * from (#54, ADR-0020). The write backdates to the source's date; the event
+ * carries `now`, because that is when it happened (#57). Only this function
+ * knows which ancestor supplied a date, so the events are planned here.
+ *
+ * `chain` runs deepest → root; `clearedIds` are the tasks losing `cleared`.
+ */
+function inheritWeakerStates(
+  cleared: TransitionState,
+  clearedIds: string[],
+  chain: LineageNode[],
+): TransitionPlan {
+  const repaired = new Set(clearedIds);
+  const now = new Date();
+
+  // How each task in the chain stands once the transition has run: the state
+  // it is losing is gone, and anything it takes on below is added as we go.
+  const after = new Map<string, Record<TransitionState, Date | null>>(
+    chain.map((n) => [
+      n.id,
+      {
+        completedAt: n.completedAt,
+        archivedAt: n.archivedAt,
+        deletedAt: n.deletedAt,
+        ...(repaired.has(n.id) ? { [cleared]: null } : {}),
+      },
+    ]),
+  );
+
+  const weaker = STATES.filter((s) => STRENGTH[s] < STRENGTH[cleared]).sort(
+    (a, b) => STRENGTH[b] - STRENGTH[a],
+  );
+
+  const writes: PlanWrite[] = [];
+  const events: PlanEvent[] = [];
+  for (const state of weaker) {
+    const taken: { id: string; value: Date; from: string }[] = [];
+    let source: { value: Date; from: string } | null = null;
+
+    for (const node of [...chain].reverse()) {
+      const held = after.get(node.id)!;
+      if (held[state]) {
+        // a task that holds it becomes the source below
+        source = { value: held[state], from: node.id };
+      } else if (!repaired.has(node.id)) {
+        source = null; // an untouched task without it breaks the run
+      } else if (source && !coveredByStronger(held, state)) {
+        held[state] = source.value;
+        taken.push({ id: node.id, ...source });
+      }
+    }
+
+    // Each task takes the date of the nearest source above it, and those can
+    // differ down one chain — hence one write per distinct date (#60).
+    for (const value of new Set(taken.map((t) => t.value))) {
+      writes.push({
+        state,
+        ids: taken.filter((t) => t.value === value).map((t) => t.id),
+        value,
+      });
+    }
+
+    // Two sources can hold the same date, so the event's `causedBy` comes
+    // from the tracked source id, never from grouping dates back apart.
+    for (const t of taken) {
+      events.push({
+        kind: KIND_THAT_SETS[state],
+        taskId: t.id,
+        at: now,
+        causedBy: t.from,
+      });
+    }
+  }
+  return { writes, events };
+}
+
+/** Whether anything the task holds outranks `state`, making it unnecessary. */
+function coveredByStronger(
+  held: Record<TransitionState, Date | null>,
+  state: TransitionState,
+): boolean {
+  return STATES.some((s) => STRENGTH[s] > STRENGTH[state] && held[s] !== null);
 }

--- a/tests/unit/domain/taskHierarchyPolicy.test.ts
+++ b/tests/unit/domain/taskHierarchyPolicy.test.ts
@@ -605,6 +605,194 @@ describe("buildTransitionPlan — strength order delete > archive > complete", (
   });
 });
 
+// ─── buildTransitionPlan: backward inherit ─────────────────────────────────────
+
+// Why this exists (#63): a stronger state covers the weaker ones, so a task
+// parked under archive is allowed to sit uncompleted below a completed
+// ancestor — the forward cascade stopped at it and kept its date (#44). Undo
+// that stronger state and the cover goes with it, leaving a state gap the
+// no-gaps invariant forbids (CONTEXT.md invariant 5). So a backward kind takes
+// on the strictly weaker states its ancestors still hold, backdated to theirs.
+const earlier = new Date("2026-02-01T09:00:00Z");
+const older = new Date("2026-01-05T08:00:00Z");
+
+describe("buildTransitionPlan — backward transitions inherit weaker ancestor states", () => {
+  it("unarchived task inherits a completed parent's date, backdated", () => {
+    const task = node("t2", "t1", { archivedAt: now });
+    const ancestors = [node("t1", null, { completedAt: earlier })];
+    const plan = buildTransitionPlan("UNARCHIVE", task, ancestors);
+
+    expect(ids(plan, "archivedAt")).toEqual(["t2"]);
+    expect(value(plan, "archivedAt")).toBeNull();
+    expect(ids(plan, "completedAt")).toEqual(["t2"]);
+    expect(value(plan, "completedAt")).toBe(earlier); // the parent's date, not now
+  });
+
+  it("every task the unarchive repairs inherits, not just the target", () => {
+    const task = node("t2", "t1", { archivedAt: now });
+    const ancestors = [
+      node("t1", "t0", { archivedAt: now }), // repaired too — loses its cover as well
+      node("t0", null, { completedAt: earlier }),
+    ];
+    const plan = buildTransitionPlan("UNARCHIVE", task, ancestors);
+
+    expect(ids(plan, "archivedAt")).toEqual(["t2", "t1"]);
+    expect(ids(plan, "completedAt")).toEqual(["t1", "t2"]);
+    expect(value(plan, "completedAt")).toBe(earlier);
+  });
+
+  it("inherits nothing when no ancestor holds a weaker state", () => {
+    const task = node("t2", "t1", { archivedAt: now });
+    const ancestors = [node("t1", null)];
+    const plan = buildTransitionPlan("UNARCHIVE", task, ancestors);
+    expect(states(plan)).toEqual(["archivedAt"]);
+  });
+
+  it("inherits nothing when the task already holds the weaker state", () => {
+    const task = node("t2", "t1", { archivedAt: now, completedAt: earlier });
+    const ancestors = [node("t1", null, { completedAt: earlier })];
+    const plan = buildTransitionPlan("UNARCHIVE", task, ancestors);
+    expect(states(plan)).toEqual(["archivedAt"]);
+  });
+
+  it("undeleted task derives its archived date from an archived ancestor", () => {
+    const task = node("t2", "t1", { deletedAt: now });
+    const ancestors = [node("t1", null, { archivedAt: earlier })];
+    const plan = buildTransitionPlan("UNDELETE", task, ancestors);
+
+    expect(ids(plan, "deletedAt")).toEqual(["t2"]);
+    expect(ids(plan, "archivedAt")).toEqual(["t2"]);
+    expect(value(plan, "archivedAt")).toBe(earlier);
+  });
+
+  it("a stronger inherited state covers the weaker one, which is not inherited", () => {
+    // t0 completed, t1 archived (uncompleted — the archive covers it), t2 deleted.
+    // Undeleting t2 pulls in archive; that cover makes completedAt unnecessary.
+    const task = node("t2", "t1", { deletedAt: now });
+    const ancestors = [
+      node("t1", "t0", { archivedAt: earlier }),
+      node("t0", null, { completedAt: earlier }),
+    ];
+    const plan = buildTransitionPlan("UNDELETE", task, ancestors);
+
+    expect(ids(plan, "archivedAt")).toEqual(["t2"]);
+    expect(states(plan)).not.toContain("completedAt");
+  });
+
+  it("a state the task still holds covers the weaker one too", () => {
+    // t2 is archived as well as deleted. Undelete clears only deletedAt; the
+    // archive it keeps still covers it, so the completed parent adds nothing.
+    const task = node("t2", "t1", { deletedAt: now, archivedAt: earlier });
+    const ancestors = [node("t1", null, { completedAt: earlier })];
+    const plan = buildTransitionPlan("UNDELETE", task, ancestors);
+    expect(states(plan)).toEqual(["deletedAt"]);
+  });
+
+  it("does not inherit through an ancestor that does not hold the state", () => {
+    // t0 completed, but t1 is not — t1 is archived, which covers it. t2's own
+    // parent has no completedAt to pass down.
+    const task = node("t2", "t1", { deletedAt: now });
+    const ancestors = [
+      node("t1", "t0", { archivedAt: earlier }),
+      node("t0", null, { completedAt: earlier }),
+    ];
+    const plan = buildTransitionPlan("UNDELETE", task, ancestors);
+    expect(ids(plan, "completedAt")).toEqual([]);
+  });
+
+  it("UNCOMPLETE inherits nothing — no state is weaker than complete", () => {
+    const task = node("t2", "t1", { completedAt: now });
+    const ancestors = [node("t1", null, { completedAt: now })];
+    const plan = buildTransitionPlan("UNCOMPLETE", task, ancestors);
+    expect(states(plan)).toEqual(["completedAt"]);
+  });
+
+  it("takes each date from the nearest source above, never one date for all", () => {
+    // t0 completed at `older`. t1 was archived by then, so t0's cascade stopped
+    // at it and t1 never completed. t2, inside that subtree, had completed at
+    // `earlier` before the archive swept it up.
+    // Unarchiving t2 repairs t1 and t2: t1 must take t0's date, while t2 keeps
+    // the one it already holds. One date for the whole run would be wrong.
+    const task = node("t2", "t1", { archivedAt: now, completedAt: earlier });
+    const ancestors = [
+      node("t1", "t0", { archivedAt: now }),
+      node("t0", null, { completedAt: older }),
+    ];
+    const plan = buildTransitionPlan("UNARCHIVE", task, ancestors);
+
+    expect(ids(plan, "archivedAt")).toEqual(["t2", "t1"]);
+    expect(plan.writes.filter((w) => w.state === "completedAt")).toEqual([
+      { state: "completedAt", ids: ["t1"], value: older },
+    ]);
+  });
+
+  // An inherited state changes the task, so it gets an event too — a task's
+  // timeline must explain why it sits archived or completed (#54, ADR-0020).
+  // `causedBy` names the ancestor the state came from.
+  it("UNDELETE under an archived ancestor emits the restore and the inherited archive", () => {
+    const task = node("t2", "t1", { deletedAt: now });
+    const ancestors = [node("t1", null, { archivedAt: earlier })];
+    const plan = buildTransitionPlan("UNDELETE", task, ancestors);
+    expect(plan.events).toEqual([
+      { kind: "UNDELETE", taskId: "t2", at: expect.any(Date) },
+      { kind: "ARCHIVE", taskId: "t2", at: expect.any(Date), causedBy: "t1" },
+    ]);
+  });
+
+  it("UNARCHIVE under a completed ancestor emits the unarchive and the inherited complete", () => {
+    const task = node("t2", "t1", { archivedAt: now });
+    const ancestors = [node("t1", null, { completedAt: earlier })];
+    const plan = buildTransitionPlan("UNARCHIVE", task, ancestors);
+    expect(plan.events).toEqual([
+      { kind: "UNARCHIVE", taskId: "t2", at: expect.any(Date) },
+      { kind: "COMPLETE", taskId: "t2", at: expect.any(Date), causedBy: "t1" },
+    ]);
+  });
+
+  it("stamps the inherit event with now — the write backdates, the event does not", () => {
+    const task = node("t2", "t1", { archivedAt: now });
+    const ancestors = [node("t1", null, { completedAt: earlier })];
+    const plan = buildTransitionPlan("UNARCHIVE", task, ancestors);
+
+    const inherit = plan.events.find((e) => e.kind === "COMPLETE")!;
+    expect(value(plan, "completedAt")).toBe(earlier); // the row keeps the old date
+    expect(inherit.at.getTime()).toBeGreaterThan(now.getTime()); // the event says when
+  });
+
+  it("a task that keeps its own weaker state, or is covered, emits nothing extra", () => {
+    // t2 already holds completedAt and keeps it; nothing is inherited.
+    const task = node("t2", "t1", { archivedAt: now, completedAt: earlier });
+    const ancestors = [node("t1", null, { completedAt: earlier })];
+    const plan = buildTransitionPlan("UNARCHIVE", task, ancestors);
+    expect(plan.events).toEqual([
+      { kind: "UNARCHIVE", taskId: "t2", at: expect.any(Date) },
+    ]);
+  });
+
+  it("each inherit event names its own source, even when two sources share one date", () => {
+    // t3 and t1 take archivedAt from different ancestors (t2 and t0) that hold
+    // the very same Date object. Grouping by date value would merge the two
+    // sources and blame the wrong ancestor — the source id must be tracked
+    // per task, like the sibling write test above tracks dates.
+    const task = node("t3", "t2", { deletedAt: now });
+    const ancestors = [
+      node("t2", "t1", { deletedAt: now, archivedAt: earlier }),
+      node("t1", "t0", { deletedAt: now }),
+      node("t0", null, { archivedAt: earlier }),
+    ];
+    const plan = buildTransitionPlan("UNDELETE", task, ancestors);
+
+    const inherits = plan.events.filter((e) => e.kind === "ARCHIVE");
+    expect(inherits).toEqual(
+      expect.arrayContaining([
+        { kind: "ARCHIVE", taskId: "t3", at: expect.any(Date), causedBy: "t2" },
+        { kind: "ARCHIVE", taskId: "t1", at: expect.any(Date), causedBy: "t0" },
+      ]),
+    );
+    expect(inherits).toHaveLength(2);
+  });
+});
+
 // ─── buildTransitionPlan: events ───────────────────────────────────────────────
 
 describe("buildTransitionPlan — events", () => {


### PR DESCRIPTION
Closes #63. Part of #57. Together with #77 this closes #54: every task a transition changes gets its own event.

**Stacked on #77 (#62)** → #76 (#60) → #75 (#59). Base is `feat/62-apply-transition`. Read the last commit only.

## Why this is needed

A stronger state covers the weaker ones. So a task parked under archive is *allowed* to sit uncompleted below a completed ancestor — the forward cascade stopped at it and kept its date (#44):

```
t0  completed          ← completed later; cascade stopped at t1
t1  archived, NOT completed   ← legal: archive covers it
```

Unarchive `t1` and the cover goes with it, leaving `t1` uncompleted under a completed `t0` — the state gap invariant 5 forbids.

## What it does

Backward kinds now take on the strictly weaker states their ancestors still hold, **backdated to the ancestor's date** rather than stamped with `now`:

- unarchived task under a completed ancestor takes that `completedAt`
- undeleted task under an archived ancestor takes that `archivedAt`
- `UNCOMPLETE` takes nothing — no state is weaker than complete

It reads the chain root-down, carrying each state's date as far as it applies. A task holding something stronger is already covered and takes nothing; a task whose parent lacks the state has nothing to take. Strongest state first, so a cover pulled in on one pass is known to the next.

## The bug the tests caught

Each task takes the date of the **nearest** source above it, and those can differ down one chain. My first version used one date for the whole run and gave a repaired ancestor its own grandchild's date. The test `takes each date from the nearest source above, never one date for all` pins it — this is exactly the case #60's "same state may repeat with different values" was built for.

## Notes

- **An inherited state gets its own event too** (#54, ADR-0020). A task's timeline must explain why it sits archived or completed — a task restored under an archived ancestor gets its `RESTORED` event *and* an `ARCHIVED` event with `causedBy: <ancestor>`. The event uses the forward kind that sets the state; the stored date stays the ancestor's while the event carries `now`. Source ids are tracked per repaired task, never recovered by grouping dates — two ancestors can hold the same `Date` and each task must name its own source (tested, same family as the nearest-source bug below).
- On the acceptance box "client restore check and server validation agree": this fixes the **server** side — undeleting under an archived ancestor now works and returns the task archived, so `validateUndelete` no longer disagrees with what `getRestoreCheck` assumes. The client actually calling the same rule is #64, which is next and stacked on this.
- Illegal backward moves are still rejected — uncomplete through an archived ancestor is covered by existing validation tests.

## Verify

**239/239 tests pass**, `tsc --noEmit` clean. `lib/domain/` still has zero imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
