### PR TITLE
Client restore preflight becomes an adapter over the domain policy (#64)

### DIFF
--- a/app/s/project/[project-id]/archive/archiveTaskList.tsx
+++ b/app/s/project/[project-id]/archive/archiveTaskList.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { TaskNode } from "@/lib/schema/task";
-import { TaskParentInfo } from "@/lib/services/project.service";
+import { TaskNode, type TaskLineage } from "@/lib/schema/task";
+import { getRestoreCheck, getAffectedSummary } from "./restoreCheck";
 import { formatTime } from "@/lib/util";
 import {
   unarchiveTaskAction,
@@ -42,88 +42,6 @@ function TrashXIcon({ className }: { className?: string }) {
       </span>
     </span>
   );
-}
-
-type RestoreCheck = {
-  canRestore: boolean;
-  description: string;
-  warning?: string;
-  affectedAncestors: TaskParentInfo[];
-};
-
-function getAffectedSummary(affectedAncestors: TaskParentInfo[]): string {
-  if (affectedAncestors.length === 0) {
-    return "";
-  }
-
-  return `Diese Aktion stellt diese Aufgabe und ${affectedAncestors.length} weitere Aufgabe${affectedAncestors.length > 1 ? "n" : ""} wieder her.`;
-}
-
-function collectAncestors(
-  task: TaskNode,
-  parentMap: Record<string, TaskParentInfo>,
-): TaskParentInfo[] {
-  const ancestors: TaskParentInfo[] = [];
-  const visited = new Set<string>();
-  let currentParentId = task.parentId;
-
-  while (currentParentId && !visited.has(currentParentId)) {
-    visited.add(currentParentId);
-    const parent = parentMap[currentParentId];
-    if (!parent) break;
-    ancestors.push(parent);
-    currentParentId = parent.parentId;
-  }
-
-  return ancestors;
-}
-
-function getRestoreCheck(
-  task: TaskNode,
-  mode: "archived" | "deleted",
-  parentMap: Record<string, TaskParentInfo>,
-): RestoreCheck {
-  const base = `Bist du dir sicher?`;
-  const ancestors = collectAncestors(task, parentMap);
-  const affectedAncestors = ancestors.filter((ancestor) =>
-    mode === "archived"
-      ? ancestor.state === "archived"
-      : ancestor.state === "deleted",
-  );
-
-  const blockingAncestor = ancestors.find((ancestor) => {
-    if (mode === "archived") return ancestor.state === "deleted";
-    return ancestor.state === "archived";
-  });
-  if (blockingAncestor) {
-    const stateLabel =
-      blockingAncestor.state === "archived" ? "archiviert" : "gelöscht";
-    return {
-      canRestore: false,
-      description: `Wiederherstellung nicht möglich — die Überaufgabe „${blockingAncestor.title}" ist ${stateLabel}.`,
-      affectedAncestors,
-    };
-  }
-
-  // If any active completed ancestor exists and this task is not completed,
-  // restoring can force completion rollback up the chain.
-  const completedAncestor = ancestors.find(
-    (ancestor) => ancestor.state === "active_completed",
-  );
-  if (completedAncestor && !task.completedAt) {
-    return {
-      canRestore: true,
-      description: base,
-      warning: `Die Überaufgabe „${completedAncestor.title}" ist als erledigt markiert.`,
-      affectedAncestors,
-    };
-  }
-
-  return {
-    canRestore: true,
-    description: base,
-    affectedAncestors,
-  };
 }
 
 function ArchiveTaskNode({
@@ -215,7 +133,7 @@ export default function ArchiveTaskList({
 }: {
   tasks: TaskNode[];
   mode: "archived" | "deleted";
-  parentMap: Record<string, TaskParentInfo>;
+  parentMap: Record<string, TaskLineage>;
 }) {
   const { showToast } = useToast();
   const [taskToRestore, setTaskToRestore] = useState<TaskNode | null>(null);

--- a/app/s/project/[project-id]/archive/restoreCheck.ts
+++ b/app/s/project/[project-id]/archive/restoreCheck.ts
@@ -1,0 +1,127 @@
+import { TaskNode, type TaskLineage } from "@/lib/schema/task";
+import {
+  validateTransition,
+  buildTransitionPlan,
+  OWN_STATE,
+  type TransitionKind,
+} from "@/lib/domain/taskHierarchyPolicy";
+
+/** What the restore dialog needs to know before it asks the user. */
+export type RestoreCheck = {
+  canRestore: boolean;
+  description: string;
+  warning?: string;
+  affectedAncestors: TaskLineage[];
+};
+
+/** Which of the two lists the user is restoring from, as the policy names it. */
+const RESTORE_KIND: Record<"archived" | "deleted", TransitionKind> = {
+  archived: "UNARCHIVE",
+  deleted: "UNDELETE",
+};
+
+export function getAffectedSummary(affectedAncestors: TaskLineage[]): string {
+  if (affectedAncestors.length === 0) {
+    return "";
+  }
+
+  return `Diese Aktion stellt diese Aufgabe und ${affectedAncestors.length} weitere Aufgabe${affectedAncestors.length > 1 ? "n" : ""} wieder her.`;
+}
+
+function collectAncestors(
+  task: TaskNode,
+  parentMap: Record<string, TaskLineage>,
+): TaskLineage[] {
+  const ancestors: TaskLineage[] = [];
+  const visited = new Set<string>();
+  let currentParentId = task.parentId;
+
+  while (currentParentId && !visited.has(currentParentId)) {
+    visited.add(currentParentId);
+    const parent = parentMap[currentParentId];
+    if (!parent) break;
+    ancestors.push(parent);
+    currentParentId = parent.parentId;
+  }
+
+  return ancestors;
+}
+
+/** How this dialog names a state the user has to be told about. */
+function stateLabel(task: TaskLineage): string {
+  if (task.deletedAt) return "gelöscht";
+  if (task.archivedAt) return "archiviert";
+  return "erledigt";
+}
+
+/**
+ * Ask the domain policy what this restore would do, and say it in German.
+ *
+ * No rule is decided here (#64). This used to be a second copy of the
+ * transition rules, written against a flattened state label, and it disagreed
+ * with the server: it refused to undelete a task under an archived ancestor,
+ * which the server has always allowed. Now the same `validateTransition` and
+ * `buildTransitionPlan` the server runs give the answer, and this only puts it
+ * into words.
+ */
+export function getRestoreCheck(
+  task: TaskNode,
+  mode: "archived" | "deleted",
+  parentMap: Record<string, TaskLineage>,
+): RestoreCheck {
+  const kind = RESTORE_KIND[mode];
+  const ancestors = collectAncestors(task, parentMap);
+
+  const validation = validateTransition(kind, task, ancestors);
+  if (!validation.valid) {
+    const blocker = validation.error.taskId
+      ? parentMap[validation.error.taskId]
+      : undefined;
+    // The blocker can be the task itself: its own state no longer allows the
+    // restore, usually because a second tab went stale. `parentMap` holds
+    // every project task, so the lookup finds it — it must not be presented
+    // as its own parent.
+    const description = !blocker
+      ? "Wiederherstellung nicht möglich."
+      : blocker.id !== task.id
+        ? `Wiederherstellung nicht möglich — die Überaufgabe „${blocker.title}" ist ${stateLabel(blocker)}.`
+        : task.deletedAt
+          ? "Wiederherstellung nicht möglich — die Aufgabe ist gelöscht."
+          : `Wiederherstellung nicht möglich — die Aufgabe ist nicht mehr ${mode === "archived" ? "archiviert" : "gelöscht"}.`;
+    return {
+      canRestore: false,
+      description,
+      affectedAncestors: [],
+    };
+  }
+
+  const plan = buildTransitionPlan(kind, task, ancestors);
+
+  // The plan's own-state write is the restore itself: this task, plus the
+  // ancestors it has to bring back along with it.
+  const affectedAncestors = plan.writes
+    .filter((w) => w.state === OWN_STATE[kind])
+    .flatMap((w) => w.ids)
+    .filter((id) => id !== task.id)
+    .map((id) => parentMap[id])
+    .filter((a): a is TaskLineage => Boolean(a));
+
+  // Any other write the plan makes on this task is a state it takes on from an
+  // ancestor to keep the tree whole (#63). The user should hear about it: the
+  // task will not come back the way they left it.
+  const inherited = plan.writes.find(
+    (w) => w.state !== OWN_STATE[kind] && w.ids.includes(task.id),
+  );
+
+  return {
+    canRestore: true,
+    description: "Bist du dir sicher?",
+    warning:
+      inherited?.state === "archivedAt"
+        ? "Die Aufgabe wird archiviert wiederhergestellt, weil eine Überaufgabe archiviert ist."
+        : inherited?.state === "completedAt"
+          ? "Die Aufgabe wird als erledigt wiederhergestellt, weil eine Überaufgabe erledigt ist."
+          : undefined,
+    affectedAncestors,
+  };
+}

--- a/lib/domain/taskHierarchyPolicy.ts
+++ b/lib/domain/taskHierarchyPolicy.ts
@@ -100,8 +100,11 @@ function writeOne(
  * state is a repair the transition makes to keep the tree legal (#63's
  * backdated inherits) — still a state change, so it gets its own event too,
  * planned where the repair is decided (`inheritWeakerStates`).
+ *
+ * Exported so a caller can tell the two apart in a plan — what the user asked
+ * for, against what had to be repaired around it (#64).
  */
-const OWN_STATE: Record<TransitionKind, TransitionState> = {
+export const OWN_STATE: Record<TransitionKind, TransitionState> = {
   COMPLETE: "completedAt",
   UNCOMPLETE: "completedAt",
   ARCHIVE: "archivedAt",
@@ -155,6 +158,12 @@ export type TransitionErrorCode = "UNEXPECTED_ERROR";
 export type ValidationError = {
   code: TransitionErrorCode;
   message: string;
+  /**
+   * The task the rule tripped on, when the rule was about a particular one.
+   * `message` is the domain's own wording; a caller that has to name the task
+   * to a user looks it up by this id and says it in its own words (#64).
+   */
+  taskId?: string;
 };
 export type ValidationResult =
   | { valid: true }
@@ -163,8 +172,12 @@ export type ValidationResult =
 function fail(
   code: ValidationError["code"],
   message: string,
+  taskId?: string,
 ): ValidationResult {
-  return { valid: false, error: { code, message } };
+  return {
+    valid: false,
+    error: { code, message, ...(taskId !== undefined ? { taskId } : {}) },
+  };
 }
 
 function ok(): ValidationResult {
@@ -173,37 +186,37 @@ function ok(): ValidationResult {
 
 /**
  * Self-state legality: whether the task's own flags permit this transition.
- * Services additionally filter their fetches (e.g. `deletedAt: null`) for
- * visibility and NOT_FOUND masking; legality itself is judged here.
+ * This is the only judge — callers fetch by id and ask, rather than filtering
+ * a wrong-state task out and calling it missing (#62).
  */
 function validateSelfState(
   kind: TransitionKind,
   task: LineageNode,
 ): ValidationResult {
   if (task.deletedAt && kind !== "UNDELETE")
-    return fail("UNEXPECTED_ERROR", "Task is deleted");
+    return fail("UNEXPECTED_ERROR", "Task is deleted", task.id);
   switch (kind) {
     case "COMPLETE":
-      if (task.archivedAt) return fail("UNEXPECTED_ERROR", "Task is archived");
+      if (task.archivedAt) return fail("UNEXPECTED_ERROR", "Task is archived", task.id);
       if (task.completedAt)
-        return fail("UNEXPECTED_ERROR", "Task is already completed");
+        return fail("UNEXPECTED_ERROR", "Task is already completed", task.id);
       return ok();
     case "UNCOMPLETE":
-      if (task.archivedAt) return fail("UNEXPECTED_ERROR", "Task is archived");
+      if (task.archivedAt) return fail("UNEXPECTED_ERROR", "Task is archived", task.id);
       if (!task.completedAt)
-        return fail("UNEXPECTED_ERROR", "Task is not completed");
+        return fail("UNEXPECTED_ERROR", "Task is not completed", task.id);
       return ok();
     case "ARCHIVE":
       if (task.archivedAt)
-        return fail("UNEXPECTED_ERROR", "Task is already archived");
+        return fail("UNEXPECTED_ERROR", "Task is already archived", task.id);
       return ok();
     case "UNARCHIVE":
       if (!task.archivedAt)
-        return fail("UNEXPECTED_ERROR", "Task is not archived");
+        return fail("UNEXPECTED_ERROR", "Task is not archived", task.id);
       return ok();
     case "UNDELETE":
       if (!task.deletedAt)
-        return fail("UNEXPECTED_ERROR", "Task is not deleted");
+        return fail("UNEXPECTED_ERROR", "Task is not deleted", task.id);
       return ok();
     case "DELETE":
       return ok();
@@ -240,9 +253,9 @@ export function validateTransition(
 function validateComplete(ancestors: LineageNode[]): ValidationResult {
   for (const a of ancestors) {
     if (a.deletedAt)
-      return fail("UNEXPECTED_ERROR", "Ancestor task is deleted");
+      return fail("UNEXPECTED_ERROR", "Ancestor task is deleted", a.id);
     if (a.archivedAt)
-      return fail("UNEXPECTED_ERROR", "Ancestor task is archived");
+      return fail("UNEXPECTED_ERROR", "Ancestor task is archived", a.id);
   }
   // Completion gap check: no uncompleted ancestor may sit between completed ancestors
   let seenUncompleted = false;
@@ -250,7 +263,7 @@ function validateComplete(ancestors: LineageNode[]): ValidationResult {
     if (!a.completedAt) {
       seenUncompleted = true;
     } else if (seenUncompleted) {
-      return fail("UNEXPECTED_ERROR", "Invalid ancestor completion chain");
+      return fail("UNEXPECTED_ERROR", "Invalid ancestor completion chain", a.id);
     }
   }
   return ok();
@@ -262,16 +275,16 @@ function validateUncomplete(
 ): ValidationResult {
   for (const a of ancestors) {
     if (a.deletedAt)
-      return fail("UNEXPECTED_ERROR", "Ancestor task is deleted");
+      return fail("UNEXPECTED_ERROR", "Ancestor task is deleted", a.id);
     if (a.archivedAt)
-      return fail("UNEXPECTED_ERROR", "Ancestor task is archived");
+      return fail("UNEXPECTED_ERROR", "Ancestor task is archived", a.id);
   }
   // Completion gap check: after the first uncompleted ancestor, no higher ancestor may be completed
   let reachedUncompleted = false;
   for (const a of ancestors) {
     if (a.completedAt) {
       if (reachedUncompleted) {
-        return fail("UNEXPECTED_ERROR", "Invalid ancestor completion chain");
+        return fail("UNEXPECTED_ERROR", "Invalid ancestor completion chain", a.id);
       }
     } else {
       reachedUncompleted = true;
@@ -283,9 +296,9 @@ function validateUncomplete(
 function validateArchive(ancestors: LineageNode[]): ValidationResult {
   for (const a of ancestors) {
     if (a.deletedAt)
-      return fail("UNEXPECTED_ERROR", "Ancestor task is deleted");
+      return fail("UNEXPECTED_ERROR", "Ancestor task is deleted", a.id);
     if (a.archivedAt)
-      return fail("UNEXPECTED_ERROR", "Ancestor task is archived");
+      return fail("UNEXPECTED_ERROR", "Ancestor task is archived", a.id);
   }
   return ok();
 }
@@ -293,14 +306,14 @@ function validateArchive(ancestors: LineageNode[]): ValidationResult {
 function validateUnarchive(ancestors: LineageNode[]): ValidationResult {
   for (const a of ancestors) {
     if (a.deletedAt)
-      return fail("UNEXPECTED_ERROR", "Ancestor task is deleted");
+      return fail("UNEXPECTED_ERROR", "Ancestor task is deleted", a.id);
   }
   // Archive gap check: after first unarchived ancestor, no higher ancestor may be archived
   let reachedUnarchived = false;
   for (const a of ancestors) {
     if (a.archivedAt) {
       if (reachedUnarchived) {
-        return fail("UNEXPECTED_ERROR", "Invalid ancestor archive chain");
+        return fail("UNEXPECTED_ERROR", "Invalid ancestor archive chain", a.id);
       }
     } else {
       reachedUnarchived = true;
@@ -312,7 +325,7 @@ function validateUnarchive(ancestors: LineageNode[]): ValidationResult {
 function validateDelete(ancestors: LineageNode[]): ValidationResult {
   for (const a of ancestors) {
     if (a.deletedAt)
-      return fail("UNEXPECTED_ERROR", "Ancestor task is deleted");
+      return fail("UNEXPECTED_ERROR", "Ancestor task is deleted", a.id);
   }
   return ok();
 }
@@ -323,7 +336,7 @@ function validateUndelete(ancestors: LineageNode[]): ValidationResult {
   for (const a of ancestors) {
     if (a.deletedAt) {
       if (reachedUndeleted) {
-        return fail("UNEXPECTED_ERROR", "Invalid ancestor deletion chain");
+        return fail("UNEXPECTED_ERROR", "Invalid ancestor deletion chain", a.id);
       }
     } else {
       reachedUndeleted = true;

--- a/lib/schema/task.ts
+++ b/lib/schema/task.ts
@@ -1,7 +1,18 @@
 import { Prisma } from "@prisma/client";
 import z from "zod";
+import type { LineageNode } from "@/lib/domain/taskHierarchyPolicy";
 
 export type TaskStatus = "OPEN" | "IN_PROGRESS" | "DONE";
+
+/**
+ * A task as its descendants' lineage sees it: what the hierarchy policy needs
+ * to judge a transition, plus the title a dialog names it by.
+ *
+ * It carries the three dates rather than one state label. Collapsing them —
+ * "archived" winning over "completed" — threw away what the policy reads, so
+ * the client had to keep its own restore rule, and the two drifted apart (#64).
+ */
+export type TaskLineage = LineageNode & { title: string };
 
 export const CreateTaskSchema = z.object({
   projectId: z.cuid(),

--- a/lib/services/project.service.ts
+++ b/lib/services/project.service.ts
@@ -14,7 +14,7 @@ import {
   ProjectWithTaskTree,
   UpdateProjectParams,
 } from "../schema/project";
-import { TaskNode } from "../schema/task";
+import { TaskNode, type TaskLineage } from "../schema/task";
 import { getActiveTimer } from "./activeTask.service";
 
 export async function createProject({
@@ -468,40 +468,14 @@ export function getDeletedTasksForProject({
 
 // ─── Task Parent Map (for restore dialogs) ─────────────────────────────────────
 
-export type TaskParentInfo = {
-  id: string;
-  parentId: string | null;
-  title: string;
-  state: "active" | "active_completed" | "archived" | "deleted";
-};
-
-type TaskParentRaw = {
-  id: string;
-  parentId: string | null;
-  title: string;
-  completedAt: Date | null;
-  archivedAt: Date | null;
-  deletedAt: Date | null;
-};
-
-function buildParentMap(
-  tasks: TaskParentRaw[],
-): Record<string, TaskParentInfo> {
-  const map: Record<string, TaskParentInfo> = {};
-  for (const t of tasks) {
-    let state: TaskParentInfo["state"];
-    if (t.deletedAt) {
-      state = "deleted";
-    } else if (t.archivedAt) {
-      state = "archived";
-    } else if (t.completedAt) {
-      state = "active_completed";
-    } else {
-      state = "active";
-    }
-    map[t.id] = { id: t.id, parentId: t.parentId, title: t.title, state };
-  }
-  return map;
+/**
+ * The project's tasks by id, in the shape the hierarchy policy reads. Both the
+ * restore dialog and the server judge a restore from this — one rule, one set
+ * of facts (#64). Handing over the raw dates is the point: this used to reduce
+ * them to a single state label, which is what forced the client to guess.
+ */
+function buildParentMap(tasks: TaskLineage[]): Record<string, TaskLineage> {
+  return Object.fromEntries(tasks.map((t) => [t.id, t]));
 }
 
 export function getProjectTaskParentMap({
@@ -537,7 +511,7 @@ export type ArchivePageData = {
   project: Project;
   archivedTasks: TaskNode[];
   deletedTasks: TaskNode[];
-  parentMap: Record<string, TaskParentInfo>;
+  parentMap: Record<string, TaskLineage>;
 };
 
 export function getArchivePageData({

--- a/tests/unit/archive/restoreCheck.test.ts
+++ b/tests/unit/archive/restoreCheck.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect } from "vitest";
+import {
+  getRestoreCheck,
+  getAffectedSummary,
+} from "@/app/s/project/[project-id]/archive/restoreCheck";
+import { validateTransition } from "@/lib/domain/taskHierarchyPolicy";
+import type { TaskNode, TaskLineage } from "@/lib/schema/task";
+
+// The restore dialog's preflight is an adapter over the domain policy (#64):
+// it must reach the same verdict the server will, and only put it into words.
+
+const now = new Date("2026-03-10T12:00:00Z");
+const earlier = new Date("2026-02-01T09:00:00Z");
+
+function lineage(
+  id: string,
+  parentId: string | null,
+  overrides: Partial<TaskLineage> = {},
+): TaskLineage {
+  return {
+    id,
+    parentId,
+    title: `Task ${id}`,
+    completedAt: null,
+    archivedAt: null,
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+/** The dialog is handed a full TaskNode; only its lineage fields matter here. */
+function taskNode(t: TaskLineage): TaskNode {
+  return t as unknown as TaskNode;
+}
+
+function mapOf(...tasks: TaskLineage[]): Record<string, TaskLineage> {
+  return Object.fromEntries(tasks.map((t) => [t.id, t]));
+}
+
+describe("getRestoreCheck — unarchive", () => {
+  it("allows a plain unarchive and names no other task", () => {
+    const task = lineage("t2", "t1", { archivedAt: now });
+    const parent = lineage("t1", null);
+    const check = getRestoreCheck(taskNode(task), "archived", mapOf(parent));
+
+    expect(check.canRestore).toBe(true);
+    expect(check.warning).toBeUndefined();
+    expect(check.affectedAncestors).toEqual([]);
+  });
+
+  it("refuses under a deleted ancestor, naming it", () => {
+    const task = lineage("t2", "t1", { archivedAt: now });
+    const parent = lineage("t1", null, { deletedAt: now, title: "Oberaufgabe" });
+    const check = getRestoreCheck(taskNode(task), "archived", mapOf(parent));
+
+    expect(check.canRestore).toBe(false);
+    expect(check.description).toContain("Oberaufgabe");
+    expect(check.description).toContain("gelöscht");
+  });
+
+  it("a refusal about the task itself does not call it its own parent", () => {
+    // Stale second tab: the task is no longer archived. parentMap holds every
+    // project task, so the blocker lookup finds the task itself — the message
+    // must not present it as "die Überaufgabe".
+    const task = lineage("t2", "t1");
+    const parent = lineage("t1", null);
+    const check = getRestoreCheck(
+      taskNode(task),
+      "archived",
+      mapOf(task, parent),
+    );
+
+    expect(check.canRestore).toBe(false);
+    expect(check.description).not.toContain("Überaufgabe");
+    expect(check.description).toContain("nicht mehr archiviert");
+  });
+
+  it("a listed task deleted in the meantime is named deleted, not as a parent", () => {
+    const task = lineage("t2", "t1", { archivedAt: now, deletedAt: now });
+    const parent = lineage("t1", null);
+    const check = getRestoreCheck(
+      taskNode(task),
+      "archived",
+      mapOf(task, parent),
+    );
+
+    expect(check.canRestore).toBe(false);
+    expect(check.description).not.toContain("Überaufgabe");
+    expect(check.description).toContain("gelöscht");
+  });
+
+  it("lists the archived ancestors that come back with it", () => {
+    const task = lineage("t2", "t1", { archivedAt: now });
+    const parent = lineage("t1", "t0", { archivedAt: now });
+    const root = lineage("t0", null);
+    const check = getRestoreCheck(
+      taskNode(task),
+      "archived",
+      mapOf(parent, root),
+    );
+
+    expect(check.canRestore).toBe(true);
+    expect(check.affectedAncestors.map((a) => a.id)).toEqual(["t1"]);
+    expect(getAffectedSummary(check.affectedAncestors)).toContain(
+      "1 weitere Aufgabe",
+    );
+  });
+
+  it("warns that a task under a completed parent comes back done (#63)", () => {
+    const task = lineage("t2", "t1", { archivedAt: now });
+    const parent = lineage("t1", null, { completedAt: earlier });
+    const check = getRestoreCheck(taskNode(task), "archived", mapOf(parent));
+
+    expect(check.canRestore).toBe(true);
+    expect(check.warning).toContain("erledigt");
+  });
+});
+
+describe("getRestoreCheck — undelete", () => {
+  it("allows a plain undelete", () => {
+    const task = lineage("t2", "t1", { deletedAt: now });
+    const parent = lineage("t1", null);
+    const check = getRestoreCheck(taskNode(task), "deleted", mapOf(parent));
+
+    expect(check.canRestore).toBe(true);
+    expect(check.warning).toBeUndefined();
+  });
+
+  // The drift this whole chain set out to fix: the dialog used to refuse this
+  // outright while the server allowed it. Now it allows it and says what the
+  // task will come back as.
+  it("allows undelete under an archived ancestor, warning it returns archived", () => {
+    const task = lineage("t2", "t1", { deletedAt: now });
+    const parent = lineage("t1", null, { archivedAt: earlier });
+    const check = getRestoreCheck(taskNode(task), "deleted", mapOf(parent));
+
+    expect(check.canRestore).toBe(true);
+    expect(check.warning).toContain("archiviert");
+  });
+});
+
+describe("getRestoreCheck — agrees with the server", () => {
+  const cases: Array<{
+    name: string;
+    task: TaskLineage;
+    ancestors: TaskLineage[];
+    mode: "archived" | "deleted";
+  }> = [
+    {
+      name: "unarchive, clean parent",
+      task: lineage("t2", "t1", { archivedAt: now }),
+      ancestors: [lineage("t1", null)],
+      mode: "archived",
+    },
+    {
+      name: "unarchive under a deleted parent",
+      task: lineage("t2", "t1", { archivedAt: now }),
+      ancestors: [lineage("t1", null, { deletedAt: now })],
+      mode: "archived",
+    },
+    {
+      name: "unarchive under a completed parent",
+      task: lineage("t2", "t1", { archivedAt: now }),
+      ancestors: [lineage("t1", null, { completedAt: earlier })],
+      mode: "archived",
+    },
+    {
+      name: "undelete under an archived parent",
+      task: lineage("t2", "t1", { deletedAt: now }),
+      ancestors: [lineage("t1", null, { archivedAt: earlier })],
+      mode: "deleted",
+    },
+    {
+      name: "undelete across a deletion gap",
+      task: lineage("t3", "t2", { deletedAt: now }),
+      ancestors: [
+        lineage("t2", "t1"), // not deleted
+        lineage("t1", null, { deletedAt: now }), // deleted above it — a gap
+      ],
+      mode: "deleted",
+    },
+  ];
+
+  it.each(cases)(
+    "$name — the dialog's verdict matches validateTransition",
+    ({ task, ancestors, mode }) => {
+      const kind = mode === "archived" ? "UNARCHIVE" : "UNDELETE";
+      const check = getRestoreCheck(
+        taskNode(task),
+        mode,
+        mapOf(...ancestors),
+      );
+      const server = validateTransition(kind, task, ancestors);
+
+      expect(check.canRestore).toBe(server.valid);
+    },
+  );
+});


### PR DESCRIPTION
Closes #64. Part of #57 — this is the last slice.

**Stacked on #78 (#63)** → #77 (#62) → #76 (#60) → #75 (#59). Base is `feat/63-backward-inherit`. Read the last commit only.

## The drift, and why it was unavoidable

`getRestoreCheck` was a second copy of the transition rules, and it disagreed with the server: it refused to undelete a task under an archived ancestor, which `validateUndelete` has always allowed. This is the drift that started #57.

It could not have agreed. The client was handed `TaskParentInfo`, whose four state labels came from collapsing the three dates with an if/else — `archived` winning over `completed`:

```ts
if (t.deletedAt) state = "deleted";
else if (t.archivedAt) state = "archived";      // a completed+archived task
else if (t.completedAt) state = "active_completed";  // is just "archived" here
```

The facts the policy reads were gone before the client saw them, so it had to guess with what was left. Fixing the rule without fixing the shape was not possible.

## What changed

- **`TaskParentInfo` → `TaskLineage`** in `lib/schema/task.ts` — a `LineageNode` plus the title, carrying the dates themselves. Nothing imports from `lib/services/` into the client any more; `buildParentMap` stops collapsing.
- **`getRestoreCheck` calls the policy**: `validateTransition` and `buildTransitionPlan`, the same rule and the same plan the server runs. It only puts the answer into German now. Extracted to `restoreCheck.ts` so it is testable — the component keeps the rendering and lost ~80 lines.
- **`ValidationError` carries `taskId`** — the task the rule tripped on. The dialog names it instead of re-deriving which ancestor blocked.
- **`OWN_STATE` is exported** — it tells the restore itself apart from the repairs around it, which is exactly what the dialog lists ("also brings back N tasks") and warns about.

## Behavior changes (intended)

| Case | Before | Now |
|---|---|---|
| undelete under an archived ancestor | dialog refused; server would have allowed it | offered, warns the task returns archived (#63 makes it inherit) |
| unarchive under a completed ancestor | warned, vaguely | warns it returns done — which is now true (#63) |

## Verify

- **246/246 tests pass**, `tsc --noEmit` clean, `next build` succeeds — the client importing `lib/domain/` does not trip #59's `server-only` guard, which is the point of that split.
- New `tests/unit/archive/restoreCheck.test.ts` (11 tests, zero-mock). The last block runs five lineages through both the dialog and `validateTransition` and asserts the verdicts match — the drift can't come back silently.
- Lint on the touched files reports only pre-existing issues; the repo's lint is not clean at baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)