### PR TITLE
Split TRANSITION_INVALID from UNEXPECTED_ERROR (#14)

### DIFF
--- a/lib/domain/taskHierarchyPolicy.ts
+++ b/lib/domain/taskHierarchyPolicy.ts
@@ -151,10 +151,23 @@ function planEvents(
 
 /**
  * The policy's own error type — deliberately not the service error shape, so
- * this domain module stays importable from client code (#57, #59). Splitting
- * a dedicated TRANSITION_INVALID code out of UNEXPECTED_ERROR is #14.
+ * this domain module stays importable from client code (#57, #59).
+ *
+ * The two codes answer different questions (#14):
+ *
+ * - `TRANSITION_INVALID` — the tree is sound; this move is not allowed on it.
+ *   Reachable through ordinary use, and the user's to fix: complete a task,
+ *   archive its parent so the cascade takes the task with it, then try to
+ *   uncomplete the task. Nothing is wrong; the answer is simply no.
+ * - `UNEXPECTED_ERROR` — the tree itself is wrong. Only the gap checks return
+ *   it: a state gap in an ancestor chain breaks invariant 5, which no sequence
+ *   of transitions can produce. Seeing it means the data is broken, not the
+ *   request.
+ *
+ * They were one code, so a refused click and a corrupt tree were told apart by
+ * reading the message.
  */
-export type TransitionErrorCode = "UNEXPECTED_ERROR";
+export type TransitionErrorCode = "TRANSITION_INVALID" | "UNEXPECTED_ERROR";
 export type ValidationError = {
   code: TransitionErrorCode;
   message: string;
@@ -194,29 +207,29 @@ function validateSelfState(
   task: LineageNode,
 ): ValidationResult {
   if (task.deletedAt && kind !== "UNDELETE")
-    return fail("UNEXPECTED_ERROR", "Task is deleted", task.id);
+    return fail("TRANSITION_INVALID", "Task is deleted", task.id);
   switch (kind) {
     case "COMPLETE":
-      if (task.archivedAt) return fail("UNEXPECTED_ERROR", "Task is archived", task.id);
+      if (task.archivedAt) return fail("TRANSITION_INVALID", "Task is archived", task.id);
       if (task.completedAt)
-        return fail("UNEXPECTED_ERROR", "Task is already completed", task.id);
+        return fail("TRANSITION_INVALID", "Task is already completed", task.id);
       return ok();
     case "UNCOMPLETE":
-      if (task.archivedAt) return fail("UNEXPECTED_ERROR", "Task is archived", task.id);
+      if (task.archivedAt) return fail("TRANSITION_INVALID", "Task is archived", task.id);
       if (!task.completedAt)
-        return fail("UNEXPECTED_ERROR", "Task is not completed", task.id);
+        return fail("TRANSITION_INVALID", "Task is not completed", task.id);
       return ok();
     case "ARCHIVE":
       if (task.archivedAt)
-        return fail("UNEXPECTED_ERROR", "Task is already archived", task.id);
+        return fail("TRANSITION_INVALID", "Task is already archived", task.id);
       return ok();
     case "UNARCHIVE":
       if (!task.archivedAt)
-        return fail("UNEXPECTED_ERROR", "Task is not archived", task.id);
+        return fail("TRANSITION_INVALID", "Task is not archived", task.id);
       return ok();
     case "UNDELETE":
       if (!task.deletedAt)
-        return fail("UNEXPECTED_ERROR", "Task is not deleted", task.id);
+        return fail("TRANSITION_INVALID", "Task is not deleted", task.id);
       return ok();
     case "DELETE":
       return ok();
@@ -253,9 +266,9 @@ export function validateTransition(
 function validateComplete(ancestors: LineageNode[]): ValidationResult {
   for (const a of ancestors) {
     if (a.deletedAt)
-      return fail("UNEXPECTED_ERROR", "Ancestor task is deleted", a.id);
+      return fail("TRANSITION_INVALID", "Ancestor task is deleted", a.id);
     if (a.archivedAt)
-      return fail("UNEXPECTED_ERROR", "Ancestor task is archived", a.id);
+      return fail("TRANSITION_INVALID", "Ancestor task is archived", a.id);
   }
   // Completion gap check: no uncompleted ancestor may sit between completed ancestors
   let seenUncompleted = false;
@@ -275,9 +288,9 @@ function validateUncomplete(
 ): ValidationResult {
   for (const a of ancestors) {
     if (a.deletedAt)
-      return fail("UNEXPECTED_ERROR", "Ancestor task is deleted", a.id);
+      return fail("TRANSITION_INVALID", "Ancestor task is deleted", a.id);
     if (a.archivedAt)
-      return fail("UNEXPECTED_ERROR", "Ancestor task is archived", a.id);
+      return fail("TRANSITION_INVALID", "Ancestor task is archived", a.id);
   }
   // Completion gap check: after the first uncompleted ancestor, no higher ancestor may be completed
   let reachedUncompleted = false;
@@ -296,9 +309,9 @@ function validateUncomplete(
 function validateArchive(ancestors: LineageNode[]): ValidationResult {
   for (const a of ancestors) {
     if (a.deletedAt)
-      return fail("UNEXPECTED_ERROR", "Ancestor task is deleted", a.id);
+      return fail("TRANSITION_INVALID", "Ancestor task is deleted", a.id);
     if (a.archivedAt)
-      return fail("UNEXPECTED_ERROR", "Ancestor task is archived", a.id);
+      return fail("TRANSITION_INVALID", "Ancestor task is archived", a.id);
   }
   return ok();
 }
@@ -306,7 +319,7 @@ function validateArchive(ancestors: LineageNode[]): ValidationResult {
 function validateUnarchive(ancestors: LineageNode[]): ValidationResult {
   for (const a of ancestors) {
     if (a.deletedAt)
-      return fail("UNEXPECTED_ERROR", "Ancestor task is deleted", a.id);
+      return fail("TRANSITION_INVALID", "Ancestor task is deleted", a.id);
   }
   // Archive gap check: after first unarchived ancestor, no higher ancestor may be archived
   let reachedUnarchived = false;
@@ -325,7 +338,7 @@ function validateUnarchive(ancestors: LineageNode[]): ValidationResult {
 function validateDelete(ancestors: LineageNode[]): ValidationResult {
   for (const a of ancestors) {
     if (a.deletedAt)
-      return fail("UNEXPECTED_ERROR", "Ancestor task is deleted", a.id);
+      return fail("TRANSITION_INVALID", "Ancestor task is deleted", a.id);
   }
   return ok();
 }

--- a/lib/services/serviceUtil.ts
+++ b/lib/services/serviceUtil.ts
@@ -13,6 +13,10 @@ export type ServiceErrorCode =
   | "AUTHORIZATION_ERROR"
   | "UNEXPECTED_ERROR"
   | "VALIDATION_ERROR"
+  // A hierarchy move the rules do not allow on a sound tree — the user's to
+  // fix, not a fault. Raised by the transition policy (#14); UNEXPECTED_ERROR
+  // keeps its meaning of "this should not be possible".
+  | "TRANSITION_INVALID"
   | "NOT_FOUND";
 
 // ─── Response Types ────────────────────────────────────────────────────────────

--- a/tests/unit/domain/taskHierarchyPolicy.test.ts
+++ b/tests/unit/domain/taskHierarchyPolicy.test.ts
@@ -65,7 +65,7 @@ describe("validateTransition — COMPLETE", () => {
     const ancestors = [node("t1", null, { deletedAt: now })];
     const result = validateTransition("COMPLETE", task, ancestors);
     expect(result.valid).toBe(false);
-    if (!result.valid) expect(result.error.code).toBe("UNEXPECTED_ERROR");
+    if (!result.valid) expect(result.error.code).toBe("TRANSITION_INVALID");
   });
 
   it("fails when an ancestor is archived", () => {
@@ -73,7 +73,7 @@ describe("validateTransition — COMPLETE", () => {
     const ancestors = [node("t1", null, { archivedAt: now })];
     const result = validateTransition("COMPLETE", task, ancestors);
     expect(result.valid).toBe(false);
-    if (!result.valid) expect(result.error.code).toBe("UNEXPECTED_ERROR");
+    if (!result.valid) expect(result.error.code).toBe("TRANSITION_INVALID");
   });
 
   it("fails when there is a completion gap in ancestors", () => {
@@ -85,8 +85,12 @@ describe("validateTransition — COMPLETE", () => {
     ];
     const result = validateTransition("COMPLETE", task, ancestors);
     expect(result.valid).toBe(false);
-    if (!result.valid)
+    // A gap means invariant 5 is already broken — no user act can ask for
+    // this, so it stays UNEXPECTED_ERROR (#14).
+    if (!result.valid) {
       expect(result.error.message).toBe("Invalid ancestor completion chain");
+      expect(result.error.code).toBe("UNEXPECTED_ERROR");
+    }
   });
 
   it("valid when ancestors are contiguously completed from parent up", () => {
@@ -151,8 +155,12 @@ describe("validateTransition — UNCOMPLETE", () => {
     ];
     const result = validateTransition("UNCOMPLETE", task, ancestors);
     expect(result.valid).toBe(false);
-    if (!result.valid)
+    // A gap means invariant 5 is already broken — no user act can ask for
+    // this, so it stays UNEXPECTED_ERROR (#14).
+    if (!result.valid) {
       expect(result.error.message).toBe("Invalid ancestor completion chain");
+      expect(result.error.code).toBe("UNEXPECTED_ERROR");
+    }
   });
 
   it("fails when an ancestor is deleted", () => {
@@ -160,7 +168,7 @@ describe("validateTransition — UNCOMPLETE", () => {
     const ancestors = [node("t1", null, { deletedAt: now })];
     const result = validateTransition("UNCOMPLETE", task, ancestors);
     expect(result.valid).toBe(false);
-    if (!result.valid) expect(result.error.code).toBe("UNEXPECTED_ERROR");
+    if (!result.valid) expect(result.error.code).toBe("TRANSITION_INVALID");
   });
 
   it("fails when an ancestor is archived", () => {
@@ -168,7 +176,7 @@ describe("validateTransition — UNCOMPLETE", () => {
     const ancestors = [node("t1", null, { archivedAt: now })];
     const result = validateTransition("UNCOMPLETE", task, ancestors);
     expect(result.valid).toBe(false);
-    if (!result.valid) expect(result.error.code).toBe("UNEXPECTED_ERROR");
+    if (!result.valid) expect(result.error.code).toBe("TRANSITION_INVALID");
   });
 
   it("fails when the task itself is archived", () => {
@@ -215,7 +223,7 @@ describe("validateTransition — ARCHIVE", () => {
     const ancestors = [node("t1", null, { archivedAt: now })];
     const result = validateTransition("ARCHIVE", task, ancestors);
     expect(result.valid).toBe(false);
-    if (!result.valid) expect(result.error.code).toBe("UNEXPECTED_ERROR");
+    if (!result.valid) expect(result.error.code).toBe("TRANSITION_INVALID");
   });
 
   it("fails when an ancestor is deleted", () => {
@@ -223,7 +231,7 @@ describe("validateTransition — ARCHIVE", () => {
     const ancestors = [node("t1", null, { deletedAt: now })];
     const result = validateTransition("ARCHIVE", task, ancestors);
     expect(result.valid).toBe(false);
-    if (!result.valid) expect(result.error.code).toBe("UNEXPECTED_ERROR");
+    if (!result.valid) expect(result.error.code).toBe("TRANSITION_INVALID");
   });
 
   it("fails when the task itself is already archived", () => {
@@ -267,8 +275,12 @@ describe("validateTransition — UNARCHIVE", () => {
     const ancestors = [node("t2", "t1"), node("t1", null, { archivedAt: now })];
     const result = validateTransition("UNARCHIVE", task, ancestors);
     expect(result.valid).toBe(false);
-    if (!result.valid)
+    // A gap means invariant 5 is already broken — no user act can ask for
+    // this, so it stays UNEXPECTED_ERROR (#14).
+    if (!result.valid) {
       expect(result.error.message).toBe("Invalid ancestor archive chain");
+      expect(result.error.code).toBe("UNEXPECTED_ERROR");
+    }
   });
 
   it("fails when an ancestor is deleted", () => {
@@ -276,7 +288,7 @@ describe("validateTransition — UNARCHIVE", () => {
     const ancestors = [node("t1", null, { deletedAt: now })];
     const result = validateTransition("UNARCHIVE", task, ancestors);
     expect(result.valid).toBe(false);
-    if (!result.valid) expect(result.error.code).toBe("UNEXPECTED_ERROR");
+    if (!result.valid) expect(result.error.code).toBe("TRANSITION_INVALID");
   });
 
   it("fails when the task itself is not archived", () => {
@@ -316,7 +328,7 @@ describe("validateTransition — DELETE", () => {
     const ancestors = [node("t1", null, { deletedAt: now })];
     const result = validateTransition("DELETE", task, ancestors);
     expect(result.valid).toBe(false);
-    if (!result.valid) expect(result.error.code).toBe("UNEXPECTED_ERROR");
+    if (!result.valid) expect(result.error.code).toBe("TRANSITION_INVALID");
   });
 
   it("fails when the task itself is already deleted", () => {
@@ -352,8 +364,12 @@ describe("validateTransition — UNDELETE", () => {
     const ancestors = [node("t2", "t1"), node("t1", null, { deletedAt: now })];
     const result = validateTransition("UNDELETE", task, ancestors);
     expect(result.valid).toBe(false);
-    if (!result.valid)
+    // A gap means invariant 5 is already broken — no user act can ask for
+    // this, so it stays UNEXPECTED_ERROR (#14).
+    if (!result.valid) {
       expect(result.error.message).toBe("Invalid ancestor deletion chain");
+      expect(result.error.code).toBe("UNEXPECTED_ERROR");
+    }
   });
 
   it("valid when all ancestors are deleted (full chain)", () => {

--- a/tests/unit/services/task.service.test.ts
+++ b/tests/unit/services/task.service.test.ts
@@ -347,7 +347,9 @@ describe("applyTransition — the policy alone judges legality", () => {
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(result.error.message).toBe(reason);
-      expect(result.error.code).not.toBe("NOT_FOUND");
+      // The tree is fine, the move just is not allowed — and that reaches the
+      // caller as its own code, not as NOT_FOUND and not as a fault (#14).
+      expect(result.error.code).toBe("TRANSITION_INVALID");
     }
   });
 


### PR DESCRIPTION
Closes #14.

**Stacked on #79 (#64)** → #78 (#63) → #77 (#62) → #76 (#60) → #75 (#59). Base is `feat/64-client-restore-adapter`. Read the last commit only.

## What

One code answered two questions. A refused click and a corrupt tree came back the same way, and only the message told them apart.

- **`TRANSITION_INVALID`** — the tree is sound, the move is not allowed on it. Reachable through ordinary use, exactly as the issue's repro says: complete a task, archive its parent so the cascade takes the task with it, then try to uncomplete it. Nothing is broken; the answer is simply no. Covers every self-state check plus the ancestor deleted/archived checks.
- **`UNEXPECTED_ERROR`** — keeps its meaning. Only the three gap checks return it now. A state gap in an ancestor chain breaks invariant 5, which no sequence of transitions can produce, so seeing it means the data is wrong, not the request.

## Where the new code goes

Added to `ServiceErrorCode` rather than folded into `VALIDATION_ERROR` — that one is about input shape, and this is not. Nothing branches on error codes today except a single `VALIDATION_ERROR` + `details` case in `time-entry-dialog.tsx`, so no caller changes.

## Note on the repro

Since #62/#63, that repro trips one step earlier — on the self-state check ("Task is archived") rather than the ancestor check ("Ancestor task is archived"), because the archive cascade reaches the task itself. Both are `TRANSITION_INVALID` now, so the issue's point stands either way.

## Verify

**246/246 tests pass**, `tsc --noEmit` clean, `next build` succeeds. The gap tests now assert `UNEXPECTED_ERROR` explicitly — they only checked the message before, so the split had nothing pinning it. A service-level test asserts the code reaches the caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)