### PR TITLE
fix: lower create form ignores entered date/time (#71)

### DIFF
--- a/components/time-entry-dialog.tsx
+++ b/components/time-entry-dialog.tsx
@@ -421,13 +421,13 @@ export default function TimeEntryDialog({
             </p>
             <div className="flex flex-col gap-2">
               <DateTimeInput
-                value={editStart}
-                onChange={setEditStart}
+                value={newStart}
+                onChange={setNewStart}
                 label="Start:"
               />
               <DateTimeInput
-                value={editEnd}
-                onChange={setEditEnd}
+                value={newEnd}
+                onChange={setNewEnd}
                 label="Ende:"
               />
             </div>


### PR DESCRIPTION
Fixes #71.

Lower create form's DateTimeInputs were bound to `editStart`/`editEnd` (the edit-entry state) while `handleCreate` sends `newStart`/`newEnd` — so typed values landed in the wrong state and the untouched one-hour default got saved. Now bound to `newStart`/`newEnd`, same as the top form.

One-line-pair change in `components/time-entry-dialog.tsx`; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)