### PR TITLE
docs: ADR-0021, ADR-0022 + CONTEXT.md from the checkpoint grill (#24)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -57,7 +57,20 @@ Completed work interval; mandatory `stoppedAt`, `duration` in seconds.
 The one running timer per user (`@@unique([userId])`, ADR-0016). Running work = ActiveTimer, finished work = TimeEntry; converting one to the other is the only transition, transactional, no overlaps.
 
 **Checkpoint**:
-Snapshot of a task + direct children (estimate, tracked time per child). First WORK_STARTED checkpoint on a task = **baseline** (`isBaseline`, scoped per-task). `existedAtBaseline` on CheckpointTask enables the scope/effort split.
+What a person believed the plan was at one moment — a frozen cross-section of a task + its direct children (estimate, tracked time per child). The record estimate-accuracy analysis grades. Records a **settled** judgment, never a change (ADR-0022); estimate judgments live here and nowhere else (ADR-0021). First WORK_STARTED checkpoint on a task = **baseline** (`isBaseline`, scoped per-task). `existedAtBaseline` on CheckpointTask enables the scope/effort split.
+_Avoid_: "snapshot" unqualified — it holds beliefs, not state; nothing is restorable from it.
+
+**Plan Checkpoint**:
+A checkpoint the user authored — they decided something (scope change, estimate change, manual save). Replaced in place until their thinking settles.
+
+**Reality Checkpoint**:
+A checkpoint the world forced — work started, or a task completed. Frozen on write, never replaced. Its value is what the user *still believed about the rest of the plan* when the fact landed.
+
+**Silence**:
+A checkpoint showing evidence arrived and the plan did not move — a sibling overran, its neighbours' estimates stayed put. Estimation evidence of its own: not acting emits no event, so only a frozen cross-section records it.
+
+**Settled Judgment**:
+A plan the user stopped editing. The unit a checkpoint stores. Individual edits inside a burst are half-formed thoughts, not judgments — which is why the debounce window exists (ADR-0022).
 
 **TodoItem**:
 Lightweight pre-task checklist entry on a task; convertible to sub-task, lineage via `convertedToTaskId`.
@@ -66,7 +79,10 @@ Lightweight pre-task checklist entry on a task; convertible to sub-task, lineage
 M:N; tags scoped per-user (ADR-0013); junction records who applied it (ADR-0014).
 
 **TaskEvent**:
-Append-only audit row per domain-meaningful mutation, 16 types, Zod-validated payloads. Records the acting user. Write-once: later corrections live in state, never in past events. Purpose: raw material for estimation-misjudgement analysis (alongside Checkpoints); no UI surface of its own. Pure audit trail: task state (datetime flags, ADR-0007) stays authoritative; events describe changes, never define them. A missed emission is a logging bug, not corruption.
+What happened — an append-only audit row per domain-meaningful mutation, Zod-validated payloads, recording the acting user. Write-once: later corrections live in state, never in past events. No UI surface of its own. Pure audit trail: task state (datetime flags, ADR-0007) stays authoritative; events describe changes, never define them. A missed emission is a logging bug, not corruption. Holds **facts only** — an estimate is a claim its author may be wrong about, so it belongs to Checkpoints (ADR-0021; `ESTIMATE_CHANGED` removal pending).
+
+**Three records, one home per fact**:
+Task fields define **current state** (ADR-0007). TaskEvents record **what happened**. Checkpoints record **what was believed** (ADR-0021). A fact with two homes has no rule for which wins when they disagree.
 
 **Status**:
 Derived from datetime flags, no enum (ADR-0007): `completedAt`, `archivedAt`, `deletedAt` (soft delete, ADR-0009). All three restorable via hierarchy transitions.
@@ -84,7 +100,7 @@ Derived from datetime flags, no enum (ADR-0007): `completedAt`, `archivedAt`, `d
 
 1. One ActiveTimer per user (DB-enforced).
 2. TaskEvents append-only — never update/delete rows.
-3. Checkpoints fire for changed task + direct parent, never grandparent+.
+3. Checkpoints fire for changed task + direct parent, never grandparent+. The parent is where the plan lives: a changed child is a *column* in the parent's cross-section, so the parent's checkpoint is the primary one, not a rollup courtesy. Grandparents hold derived totals, not beliefs.
 4. At most one baseline checkpoint per task.
 5. No state gaps in ancestor chains (e.g. completed ancestor above uncompleted descendant = integrity error, policy-enforced).
 6. Soft-deleted rows filtered from every query.

--- a/docs/adr/0021-estimate-judgements-live-in-checkpoints.md
+++ b/docs/adr/0021-estimate-judgements-live-in-checkpoints.md
@@ -1,0 +1,29 @@
+# Estimate judgements live in checkpoints, not the ledger
+
+Grilled 2026-07-17 (`/grill-with-docs`, #24). Three records, one home per fact:
+
+- **Task fields** define **current state** (ADR-0007). The only authority.
+- **TaskEvents** record **what happened** — the change log. They describe changes, never define state.
+- **Checkpoints** record **what the user believed** — the material for judging estimate accuracy.
+
+**Decision:** estimate judgements belong to checkpoints alone. `ESTIMATE_CHANGED` (schema in `event.service.ts`, emitted from `task.service.ts`, wired in #51) is **removed**. It put a judgement in the ledger, which gave estimates two homes and no rule for which wins — and they are guaranteed to disagree, because checkpoints are debounced (ADR-0022) and the ledger is not.
+
+`STARTED` (event: work began) and the baseline checkpoint (belief: this was the plan) firing at the same instant is not duplication. Different questions, different records.
+
+## Why an estimate is not "what happened"
+
+The line is not "state vs history" — both records are historical. It is **fact vs belief**. `COMPLETED` is a fact: it happened, it is not revisable, and its truth does not depend on who wrote it. An estimate is a claim about the future that its author may be wrong about — and being wrong about it *is the product*. Facts go in the ledger; claims go in checkpoints where accuracy analysis (#26) can grade them.
+
+## Every task can hold a checkpoint
+
+Required by this ADR, not incidental. A leaf task gets a `Checkpoint` row with **zero `CheckpointTask` rows** and `ownEstimate` set — a cross-section with no columns. Without this, a standalone root task with no children has no parent checkpoint to appear in and no checkpoint of its own, so its estimate judgements would have no home once `ESTIMATE_CHANGED` is gone. `CheckpointTask` rows are the *columns* — one per direct child (invariant 3), never grandchildren.
+
+## Considered options
+
+**Keep `ESTIMATE_CHANGED` and write an authority rule** ("the ledger owns what changed, the checkpoint owns what the plan was"). Rejected: it buys fine-grained estimate history at the price of two sources of truth about the same fact, forever, plus a rule every future reader must know before touching either. The split above needs no such rule — the seam does the work.
+
+## Consequences
+
+- **The intra-burst wobble is lost, deliberately.** Estimate moves inside one debounce window (2h → 3h → 2.5h before settling) are recorded nowhere. A half-formed judgement is not a judgement (ADR-0022). This is one-way: if that fiddling is ever wanted, it was never written down.
+- Anything asking "how did this estimate move?" reads checkpoints, never events. A future `ESTIMATE_CHANGED`-shaped event type is this ADR being reversed, not extended.
+- `CheckpointTask` must carry `title` — a checkpoint is read years later and must stand alone. Joining to `Task` gives the title *now*, and gives nothing for a task since deleted.

--- a/docs/adr/0022-plan-checkpoints-debounce-reality-checkpoints-freeze.md
+++ b/docs/adr/0022-plan-checkpoints-debounce-reality-checkpoints-freeze.md
@@ -1,0 +1,36 @@
+# Plan checkpoints debounce, reality checkpoints freeze
+
+Grilled 2026-07-17 (`/grill-with-docs`, #24). A checkpoint records a **settled** judgement, not a change. Adding a sub-task with an estimate is a judgement, but a partial one — you are mid-thought. Add four more, tweak two estimates, stop: *now* there is a plan worth freezing and worth being graded against later. One thought, not five keystrokes.
+
+**Decision:** checkpoints split into two families with different write rules.
+
+| | **Plan checkpoint** | **Reality checkpoint** |
+|---|---|---|
+| Triggers | `SCOPE_CHANGE`, `ESTIMATE_CHANGE`, `MANUAL` | `WORK_STARTED` (baseline), `TASK_COMPLETED` |
+| Authored by | the user | the world |
+| Records | what was decided | what was still believed when facts landed |
+| Write rule | **replace in place** while the window is open | **freeze on write**, never replaced |
+
+## Debounce is the definition, not an optimisation
+
+The retired roadmap justified the window as noise reduction — "adding 5 sub-tasks shouldn't make 5 rows." That is a performance argument and it is the wrong one. The window is **how the app detects that thinking finished**. Keeping the intermediate states would mean grading the user on sentences they had not finished writing.
+
+Hence *destructive replace* (the open question in #24): inside the window there is exactly **one** checkpoint, overwritten until the judgement settles. Not append.
+
+**The window closes on the earlier of: 30 minutes idle, or `WORK_STARTED`.** A timer alone is a weak proxy for "I stopped thinking" and has a real failure: plan for 3 minutes, start work, keep editing for 25 — the window is still open, so the baseline gets overwritten by edits made *after* work began. Starting a timer is the strongest available signal that planning ended. It makes the baseline exact by construction instead of by luck.
+
+## Why reality checkpoints must not debounce
+
+Complete task A at 14:00 (50% over its estimate), react at 14:05 by raising sibling B to 3h. Under one shared window the reaction **overwrites** the moment reality landed — destroying the exact signal the checkpoint existed to catch.
+
+That signal is **silence**. If A finishes 50% over and B and C sit untouched, the checkpoint records a *failure to update*: evidence arrived and the plan did not move. Not acting emits no event, so no ledger replay can find it (ADR-0021). Only a frozen cross-section catches an omission.
+
+## Why `TASK_COMPLETED` stays
+
+It looks like an outcome — derivable from `completedAt` plus TimeEntry rows, and outcomes are the answer key, not a guess. The reason it stays: at the moment A completes, the interesting snapshot is not A. It is **B and C**. Completion is when a task's actual time stops being provisional, and a frozen cross-section is the only record of what was still believed about the rest of the plan at that instant.
+
+## Consequences
+
+- Two write paths in `checkpoint.service.ts`, not one. A trigger that picks the wrong family is a silent data bug: a debounced baseline loses the plan, a frozen plan-checkpoint litters history with half-thoughts.
+- `WORK_STARTED` both **closes** the plan window and **writes** the baseline. Order matters: settle the open plan checkpoint first, then freeze the baseline.
+- Long-horizon plans are underserved. Baseline + completion on a year-long task means the first sharpening signal arrives in a year. An **estimate-exceeded** trigger (tracked crosses estimate while work continues) would catch drift mid-flight — deliberately left open, to be decided once #26 has produced real numbers.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "sandcastle": "tsx .sandcastle/main.mts",
     "test:watch": "vitest",


### PR DESCRIPTION
Design docs from the `/grill-with-docs` session on #24. **No code** — decisions only.

## The model

Task fields define **current state** (ADR-0007). TaskEvents record **what happened**. Checkpoints record **what was believed**. One home per fact.

The line isn't "state vs history" — both are historical. It's **fact vs belief**. `COMPLETED` happened and isn't revisable. An estimate is a claim its author may be wrong about, and being wrong about it *is the product*.

## ADR-0021 — estimate judgements live in checkpoints, not the ledger

`ESTIMATE_CHANGED` (wired in #51, three days ago) is removed. It gave estimates two homes with no rule for which wins — and they're guaranteed to disagree, since checkpoints debounce and the ledger doesn't.

Rejected alternative: keep both, write an authority rule. Buys fine-grained history at the price of two sources of truth forever.

**Cost, deliberate and one-way**: the intra-burst wobble (2h → 3h → 2.5h before settling) is recorded nowhere.

Also settles #24's open question — leaf tasks get a `Checkpoint` row with **zero `CheckpointTask` rows** and `ownEstimate` set. Required, not incidental: otherwise a standalone root task's judgements have no home once `ESTIMATE_CHANGED` is gone.

## ADR-0022 — plan checkpoints debounce, reality checkpoints freeze

A checkpoint stores a **settled** judgement. The debounce window is how the app detects that thinking finished — not noise reduction. So: **destructive replace** (#24's other open question).

Reality checkpoints (`WORK_STARTED`, `TASK_COMPLETED`) freeze on write. Overwriting them would destroy **silence**: A overran, B and C sat untouched. Not acting emits no event, so only a frozen cross-section catches an omission.

Window closes on 30 min idle **or** `WORK_STARTED` — a timer alone lets post-work edits overwrite the baseline.

## Also

- Toggl bulk-import bypass **dropped** — roadmap #40 already demoted it to "a consideration, not a requirement"
- Invariant 3 keeps a better reason: the parent is where the plan lives
- `estimatedTotal` = direct children only
- #24's checklist rewritten to match

## Left open

- **Estimate-exceeded trigger** — baseline + completion is a feedback loop as long as the task. Fine at 2h, useless on a year-long plan.
- **Build order** — the estimate-history view is buildable today from the live ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
