### PR TITLE
fix: drop the install hook from the planner run

### DIFF
--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -43,8 +43,16 @@ const planSchema = z.object({
 // Raise this if your backlog is large; lower it for a quick smoke-test run.
 const MAX_ITERATIONS = 10;
 
-// Hooks run inside the sandbox before the agent starts each iteration.
-// npm install ensures the sandbox always has fresh dependencies.
+// Hooks run inside the sandbox before the agent starts each iteration, so the
+// agent has dependencies installed.
+//
+// Only pass these to runs that get their own worktree (i.e. that pass a
+// branch). A run without a branch bind-mounts the host checkout itself, whose
+// node_modules was built on macOS: pnpm sees the host's storeDir in
+// .modules.yaml, wants to wipe the directory, finds no TTY, and aborts with
+// ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY. Forcing it through (CI=true)
+// would be worse — it would overwrite the host's node_modules with Linux
+// binaries and break local dev.
 const hooks = {
   sandbox: {
     onSandboxReady: [
@@ -80,7 +88,9 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
   // It outputs a <plan> JSON block — Output.object parses and validates it.
   // -------------------------------------------------------------------------
   const plan = await sandcastle.run({
-    hooks,
+    // No install hook: this run has no branch, so it bind-mounts the host
+    // checkout (see the hooks comment above). The planner only reads issues
+    // via gh and reasons about them — it never needs node_modules.
     sandbox: docker(),
     name: "planner",
     // One iteration is enough: the planner just needs to read and reason,


### PR DESCRIPTION
## Symptom

`pnpm sandcastle` died at "Setting up sandbox" with a bare `exit 1` — visually identical to the corepack failure fixed in #83, but a different cause.

## Why it was invisible

Sandcastle **discards hook stdout** and only surfaces stderr in the `ExecError`. The original corepack traceback showed up only because corepack writes to stderr. A probe hook echoing to stderr revealed the truth:

```
=== PWD ===            /home/agent/workspace
=== branch/commit ===  main-vibe  cc000c8
=== node_modules? ===  YES-node_modules
=== storeDir ===       "/Users/efte/.pnpm-store/v10"     <- host macOS store
=== corepack cache === 10.29.2                           <- #83 working
=== real install ===   ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY
```

## Root cause

`sandcastle.run()` **without a `branch` bind-mounts the host checkout** instead of creating a worktree — the listing shows `.next`, `.DS_Store`, `.env`, untracked files no clean worktree would have. That checkout carries macOS `node_modules`, whose `storeDir` doesn't exist in Linux. pnpm decides the store changed, tries to wipe the directory, finds no TTY, aborts.

This is why #83's `copyToWorktree` fix didn't help: the planner never passed `copyToWorktree` — it only reaches `createSandbox()` in Phase 2.

## Fix

Drop the hook from the planner. It only runs `gh issue list` and reasons; it never needs `node_modules`. The implementer/reviewer keep the hook — they pass a `branch`, so they get a clean worktree where the install works.

**`CI=true` would be the wrong fix** — pnpm would overwrite the host's `node_modules` with Linux binaries and break local dev.

## Verified

Planner reaches the agent and returns a plan (issues 86, 59).

## Known remaining issue — merger (line 228)

The merger has the same shape (`hooks`, no `branch`) and **will hit this same abort**. It's deeper: `merge-prompt.md` tells it to run `npm run typecheck` and `npm run test`, but
- there is no `typecheck` script in `package.json`, and
- the host `node_modules` it would mount are macOS binaries that can't execute in Linux.

Left alone pending a call on whether the merge phase should verify at all, given implementer+reviewer already test in their own worktrees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)