### PR TITLE
feat: CheckpointTask.title + estimatedTotal semantics (#86)

### DIFF
--- a/prisma/migrations/20260717000000_checkpoint_task_add_title/migration.sql
+++ b/prisma/migrations/20260717000000_checkpoint_task_add_title/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+-- CheckpointTask is empty (no code writes checkpoints yet), so the required
+-- column needs no backfill and no default.
+ALTER TABLE `CheckpointTask` ADD COLUMN `title` VARCHAR(191) NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -168,7 +168,7 @@ model Checkpoint {
     label                    String?
     isBaseline               Boolean           @default(false)
     childCount               Int
-    estimatedTotal           Int? // in minutes, sum of task and subtasks
+    estimatedTotal           Int? // in minutes, the task's own estimate plus its direct children only (never grandchildren)
     trackedTotal             Int // in seconds, sum of task and subtasks
     ownEstimate              Int? // in minutes, only the task's own estimate
     newChildrenSinceBaseline Int               @default(0)
@@ -183,6 +183,7 @@ model CheckpointTask {
     Checkpoint          Checkpoint  @relation(fields: [checkpointId], references: [id])
     taskId              String
     task                Task        @relation(fields: [taskId], references: [id])
+    title               String
     estimate            Int? // in minutes
     trackedSoFar        Int // in seconds
     existedAtBaseline   Boolean


### PR DESCRIPTION
Closes #86 (PRD #24).

Recovers work that sandcastle implemented and reviewed but never merged (the merge phase was broken at the time).

## Changes
- Add required `CheckpointTask.title` (`VARCHAR NOT NULL`) + migration `20260717000000_checkpoint_task_add_title`. No backfill/default — both checkpoint tables are empty (no code writes checkpoints yet), per ADR-0021.
- Clarify `Checkpoint.estimatedTotal` comment: the task's own estimate plus **direct children only**, never grandchildren (resolves the old ambiguous "sum of task and subtasks" wording).

## Verification (from the sandcastle run)
- `prisma generate` → `CheckpointTask.title: string` present
- `tsc --noEmit` clean
- 252/252 tests pass
- Migration not yet applied to a live DB (none in the sandbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)